### PR TITLE
[DRAFT][EXPERIMENTAL] Identity, sharing, provenance, and admin visibility stack

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -104,6 +104,21 @@ catalog_file = "./server/tool_catalog.json"
 allow_assistant_tool_blocks = true
 max_calls_per_message = 4
 
+[tenant_policy]
+default_tenant_id = "default"
+public_sharing_enabled = false
+persona_resource_owner = "active_user" # persona | active_user | tenant
+missing_access_default = "allow_owner" # allow_owner | allow_tenant | deny | single_user_compatible
+audit_verbosity = "mutations" # off | mutations | decisions | verbose
+
+[tenant_policy.visibility_defaults]
+conversation = "private"
+message = "private"
+memory = "private"
+file = "private"
+artifact = "private"
+project = "private"
+
 [providers.openai]
 type = "openai"
 base_url = "https://api.openai.com/v1"

--- a/config.toml
+++ b/config.toml
@@ -106,10 +106,37 @@ max_calls_per_message = 4
 
 [tenant_policy]
 default_tenant_id = "default"
+policy_preset = "personal" # personal | household | corporate
 public_sharing_enabled = false
 persona_resource_owner = "active_user" # persona | active_user | tenant
 missing_access_default = "allow_owner" # allow_owner | allow_tenant | deny | single_user_compatible
 audit_verbosity = "mutations" # off | mutations | decisions | verbose
+owner_can_archive = true
+owner_can_soft_remove = true
+owner_can_permanent_remove = false
+tenant_admin_manage_all = true
+global_admin_manage_all = true
+tenant_admin_can_permanent_remove = false
+
+[tenant_policy.retention_windows]
+soft_delete_days = 30
+permanent_delete_days = 90
+audit_event_days = 365
+
+[tenant_policy.presets.personal]
+missing_access_default = "allow_owner"
+owner_can_soft_remove = true
+owner_can_permanent_remove = false
+
+[tenant_policy.presets.household]
+missing_access_default = "allow_tenant"
+owner_can_soft_remove = true
+owner_can_permanent_remove = false
+
+[tenant_policy.presets.corporate]
+missing_access_default = "deny"
+owner_can_soft_remove = false
+tenant_admin_can_permanent_remove = true
 
 [tenant_policy.visibility_defaults]
 conversation = "private"

--- a/config.toml.example
+++ b/config.toml.example
@@ -101,10 +101,37 @@ max_calls_per_message = 4
 
 [tenant_policy]
 default_tenant_id = "default"
+policy_preset = "personal" # personal | household | corporate
 public_sharing_enabled = false
 persona_resource_owner = "active_user" # persona | active_user | tenant
 missing_access_default = "allow_owner" # allow_owner | allow_tenant | deny | single_user_compatible
 audit_verbosity = "mutations" # off | mutations | decisions | verbose
+owner_can_archive = true
+owner_can_soft_remove = true
+owner_can_permanent_remove = false
+tenant_admin_manage_all = true
+global_admin_manage_all = true
+tenant_admin_can_permanent_remove = false
+
+[tenant_policy.retention_windows]
+soft_delete_days = 30
+permanent_delete_days = 90
+audit_event_days = 365
+
+[tenant_policy.presets.personal]
+missing_access_default = "allow_owner"
+owner_can_soft_remove = true
+owner_can_permanent_remove = false
+
+[tenant_policy.presets.household]
+missing_access_default = "allow_tenant"
+owner_can_soft_remove = true
+owner_can_permanent_remove = false
+
+[tenant_policy.presets.corporate]
+missing_access_default = "deny"
+owner_can_soft_remove = false
+tenant_admin_can_permanent_remove = true
 
 [tenant_policy.visibility_defaults]
 conversation = "private"

--- a/config.toml.example
+++ b/config.toml.example
@@ -99,6 +99,21 @@ catalog_file = "./server/tool_catalog.json"
 allow_assistant_tool_blocks = true
 max_calls_per_message = 4
 
+[tenant_policy]
+default_tenant_id = "default"
+public_sharing_enabled = false
+persona_resource_owner = "active_user" # persona | active_user | tenant
+missing_access_default = "allow_owner" # allow_owner | allow_tenant | deny | single_user_compatible
+audit_verbosity = "mutations" # off | mutations | decisions | verbose
+
+[tenant_policy.visibility_defaults]
+conversation = "private"
+message = "private"
+memory = "private"
+file = "private"
+artifact = "private"
+project = "private"
+
 [providers.openai]
 type = "openai"
 base_url = "https://api.openai.com/v1"

--- a/docs/active-queue.yaml
+++ b/docs/active-queue.yaml
@@ -1,0 +1,21 @@
+queue_name: wyrmgpt-identity-sharing-burndown
+updated_at: 2026-06-12T18:35:00Z
+source: https://github.com/doctomiko/wyrmgpt/issues
+default_order: issue_number
+items:
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 7
+  - 8
+  - 9
+  - 10
+  - 11
+  - 12
+notes:
+  1: "Small Python/SQLite startup compatibility fix."
+  2: "Design anchor; mirror or confirm durable docs before implementation issues."
+  3: "First backend implementation issue in the identity/sharing stream."

--- a/docs/active-queue.yaml
+++ b/docs/active-queue.yaml
@@ -1,5 +1,5 @@
 queue_name: wyrmgpt-identity-sharing-burndown
-updated_at: 2026-06-12T18:35:00Z
+updated_at: 2026-06-13T01:14:30Z
 source: https://github.com/doctomiko/wyrmgpt/issues
 default_order: issue_number
 items:
@@ -15,7 +15,13 @@ items:
   - 10
   - 11
   - 12
+  - 13
+  - 14
+  - 15
 notes:
   1: "Small Python/SQLite startup compatibility fix."
   2: "Design anchor; mirror or confirm durable docs before implementation issues."
   3: "First backend implementation issue in the identity/sharing stream."
+  13: "Admin bulk reassignment tools for ownership, provenance, sharing, and persona access."
+  14: "Library/asset UI surfaces ownership, provenance, sharing, and persona access with admin edits."
+  15: "Permission-control visible UI surfaces and add admin visibility toggles."

--- a/docs/dev-docs/wyrmgpt_identity_sharing_design.md
+++ b/docs/dev-docs/wyrmgpt_identity_sharing_design.md
@@ -1,0 +1,224 @@
+# WyrmGPT Identity, Sharing, and Access Control Design
+
+## 1. Purpose
+
+WyrmGPT is currently a local-first, mostly single-user application. The next schema stream adds the durable model needed for identity ownership, resource sharing, access checks, tenant policy, and auditability without turning the app into a SaaS control plane.
+
+This document is the design anchor for issues #3 through #12. Implementation should stay incremental: add schema and helpers first, preserve current single-user behavior by default, then route resource-specific behavior through the shared resolver.
+
+## 2. Design Goals
+
+- Preserve existing local, single-user behavior when no explicit identity or policy is configured.
+- Make ownership and provenance explicit on shareable resources.
+- Support allow and deny access-control entries with deterministic precedence.
+- Add tenant-scoped groups and roles without requiring multi-tenant hosting.
+- Centralize policy and effective-access resolution so routes do not duplicate authorization logic.
+- Record audit events for security-relevant decisions and mutations.
+- Keep diagnostics explainable for UI and API consumers.
+
+## 3. Core Concepts
+
+### Tenant
+
+A tenant is a policy and identity namespace. The default deployment should create or assume a `default` tenant. Tenant IDs should be stable text identifiers so imports, connectors, and future deployments can map external identity namespaces without relying on local integer IDs.
+
+### Principal
+
+A principal is the actor being evaluated. Principal kinds should include:
+
+- `user`
+- `persona`
+- `service`
+- `group`
+- `role`
+- `public`
+
+The resolver should accept a principal context that includes the direct user or persona plus derived group and role memberships.
+
+### Resource
+
+A resource is anything that can be owned, shared, or inherited into context. Initial shareable resource types are:
+
+- `conversation`
+- `message`
+- `memory`
+- `file`
+- `artifact`
+- `project`
+
+Resource IDs should be stored as text in generic access tables so integer and UUID primary keys can coexist.
+
+### Owner
+
+The owner is the principal with default administrative control of a resource. A resource may also have a tenant owner or project owner for inherited policy, but a single explicit `owner_principal_type` and `owner_principal_id` should be present on resources that can be shared directly.
+
+### Provenance
+
+Provenance records where a resource came from and who or what created it. Provenance should be queryable enough for diagnostics and audit trails, not just human prose.
+
+Recommended fields on shareable resources:
+
+- `tenant_id`
+- `owner_principal_type`
+- `owner_principal_id`
+- `created_by_principal_type`
+- `created_by_principal_id`
+- `source_principal_type`
+- `source_principal_id`
+- `visibility`
+- `sharing_mode`
+- `provenance_json`
+
+## 4. Access-Control Entries
+
+Use a generic `access_control_entries` table for direct grants and denials.
+
+Recommended shape:
+
+- `id TEXT PRIMARY KEY`
+- `tenant_id TEXT NOT NULL`
+- `resource_type TEXT NOT NULL`
+- `resource_id TEXT NOT NULL`
+- `principal_type TEXT NOT NULL`
+- `principal_id TEXT NOT NULL`
+- `effect TEXT NOT NULL` with `allow` or `deny`
+- `action TEXT NOT NULL` such as `read`, `write`, `share`, `admin`, `delete`, `audit`
+- `scope TEXT NOT NULL DEFAULT 'resource'`
+- `inherited_from_type TEXT`
+- `inherited_from_id TEXT`
+- `reason TEXT`
+- `created_by_principal_type TEXT`
+- `created_by_principal_id TEXT`
+- `created_at TEXT NOT NULL`
+- `expires_at TEXT`
+- `is_deleted INTEGER NOT NULL DEFAULT 0`
+
+Indexes should support lookup by resource, principal, tenant, and `(resource_type, resource_id, action)`.
+
+## 5. Precedence Rules
+
+Access resolution should be deterministic and explainable.
+
+Recommended order:
+
+1. Tenant policy hard deny.
+2. Explicit resource deny for the principal, role, group, or public principal.
+3. Owner administrative access.
+4. Explicit resource allow for the principal, role, group, or public principal.
+5. Inherited deny from project, conversation, or parent resource.
+6. Inherited allow from project, conversation, or parent resource.
+7. Resource visibility fallback.
+8. Tenant policy default.
+
+Deny should win over allow at the same or broader level unless tenant policy explicitly defines a narrower exception model later. Expired and soft-deleted entries do not participate.
+
+## 6. Groups and Roles
+
+Groups and roles are tenant-scoped.
+
+Recommended tables:
+
+- `identity_groups`
+- `identity_group_members`
+- `identity_roles`
+- `identity_role_assignments`
+
+Groups represent membership sets. Roles represent policy capabilities. A group may receive role assignments, and a user or persona may receive roles directly. Membership records should be soft-deletable and auditable.
+
+## 7. Tenant Policy
+
+Tenant policy should be loaded from TOML defaults, then resolved through a small policy API.
+
+Initial policy keys:
+
+- default tenant ID
+- default visibility for new conversations, memories, files, artifacts, and projects
+- whether public sharing is enabled
+- whether persona-created resources are owned by the persona, the active user, or the tenant
+- default action for missing access entries: allow local owner only, allow tenant members, or deny
+- audit verbosity: off, mutations, decisions, or verbose
+
+Configuration should be additive. Missing policy files must not break local startup.
+
+## 8. Audit Events
+
+Audit logging should be append-only for security-relevant events.
+
+Recommended `audit_events` shape:
+
+- `id TEXT PRIMARY KEY`
+- `tenant_id TEXT NOT NULL`
+- `event_type TEXT NOT NULL`
+- `actor_principal_type TEXT`
+- `actor_principal_id TEXT`
+- `resource_type TEXT`
+- `resource_id TEXT`
+- `action TEXT`
+- `decision TEXT`
+- `reason TEXT`
+- `request_id TEXT`
+- `source_ip TEXT`
+- `user_agent TEXT`
+- `metadata_json TEXT`
+- `created_at TEXT NOT NULL`
+
+Helpers should make logging cheap and safe: failures to write low-risk audit events should not crash normal local operation, but schema failures during startup should still be visible.
+
+## 9. Central Access Resolver
+
+The resolver should expose one backend function that route and DB helpers can call:
+
+```python
+resolve_access(principal, resource, action, *, explain=False) -> AccessDecision
+```
+
+`AccessDecision` should include:
+
+- `allowed: bool`
+- `effect: "allow" | "deny"`
+- `reason: str`
+- `matched_entries: list[dict]`
+- `inherited_from: list[dict]`
+- `policy: dict`
+- `explain: list[str]`
+
+The first implementation can live near DB access helpers, but route code should only depend on the public resolver API.
+
+## 10. Resource Inheritance
+
+Initial inheritance rules:
+
+- Messages inherit from their conversation.
+- Conversation artifacts inherit from their conversation unless explicitly overridden.
+- Project conversations, files, artifacts, and memories inherit from their project.
+- File-derived artifacts inherit from the source file.
+- Memories may be persona-scoped, project-scoped, conversation-scoped, global, or directly shared.
+
+Resource tables should keep enough owner and provenance fields to explain why a resource appears in context.
+
+## 11. Diagnostics API and UI
+
+Diagnostics should answer: who can see this, why, and where did the access come from?
+
+API output should include the effective decision, owner fields, visibility, direct ACEs, inherited ACEs, group and role membership used, tenant policy defaults, and audit event references when available.
+
+The UI should present this as a compact inspection panel for a selected conversation, memory, file, artifact, or project. It should not require users to understand table internals.
+
+## 12. Issue Mapping
+
+- #3 adds `audit_events` schema and audit logging helpers.
+- #4 adds owner and provenance fields to shareable resources.
+- #5 adds generic access-control entries.
+- #6 adds tenant-scoped groups and roles.
+- #7 adds TOML policy defaults and resolver hooks.
+- #8 adds the central access resolver with explain output.
+- #9 updates conversations and messages for ownership, persona identity, and inherited access.
+- #10 updates memories for persona assignment and persona-context access.
+- #11 updates files, artifacts, and projects for inherited sharing and ownership metadata.
+- #12 adds effective sharing diagnostics API and UI.
+
+## 13. Compatibility Notes
+
+Existing data should migrate into tenant `default` with owner fields unset or assigned to a local default principal. The resolver must treat legacy rows without owner fields as accessible under current single-user behavior until stricter policy is explicitly configured.
+
+No migration in this stream should delete user data or require external identity services.

--- a/docs/dev-docs/wyrmgpt_identity_sharing_design.md
+++ b/docs/dev-docs/wyrmgpt_identity_sharing_design.md
@@ -35,6 +35,14 @@ A principal is the actor being evaluated. Principal kinds should include:
 
 The resolver should accept a principal context that includes the direct user or persona plus derived group and role memberships.
 
+Local-first installs should use stable canonical actor names when no external identity provider is configured:
+
+- the default human user is `Doc`;
+- the default assistant persona is `Doc Tomiko`;
+- persisted IDs should remain stable machine IDs such as `local` or a persona UUID, while display names stay mutable profile data.
+
+Code should not infer permissions from display names. Display names are for diagnostics, audit summaries, and UI labels only.
+
 ### Resource
 
 A resource is anything that can be owned, shared, or inherited into context. Initial shareable resource types are:
@@ -45,6 +53,7 @@ A resource is anything that can be owned, shared, or inherited into context. Ini
 - `file`
 - `artifact`
 - `project`
+- `user_profile`
 
 Resource IDs should be stored as text in generic access tables so integer and UUID primary keys can coexist.
 
@@ -68,6 +77,20 @@ Recommended fields on shareable resources:
 - `visibility`
 - `sharing_mode`
 - `provenance_json`
+
+### User Profiles and About You
+
+Human profile data is a `user_profile` resource. The built-in personal profile shown as "About You" belongs to the active human user, not to a persona. Persona memories must not be used as the canonical store for About You facts.
+
+Recommended profile behavior:
+
+- a profile row has `tenant_id`, `user_id`, `display_name`, and the same owner/provenance fields used by other directly shareable resources;
+- the default profile for local installs has stable user ID `local` and display name `Doc`;
+- profile content can be read by personas only through explicit policy or resolver defaults for persona context use;
+- profile edits are user-driven mutations and should produce audit events once audit logging exists;
+- diagnostics should be able to explain why a human user, admin, or persona can read About You data.
+
+Persona configuration is separate profile-like data for assistant identities. The default local persona display name is `Doc Tomiko`, but persona display names are not access-control principals. Persona IDs are principals when the persona acts, receives memory assignment, or is evaluated for `use_in_context`.
 
 ## 4. Access-Control Entries
 
@@ -153,9 +176,14 @@ Recommended `audit_events` shape:
 - `actor_principal_id TEXT`
 - `resource_type TEXT`
 - `resource_id TEXT`
+- `target_principal_type TEXT`
+- `target_principal_id TEXT`
 - `action TEXT`
 - `decision TEXT`
 - `reason TEXT`
+- `summary TEXT`
+- `before_json TEXT`
+- `after_json TEXT`
 - `request_id TEXT`
 - `source_ip TEXT`
 - `user_agent TEXT`
@@ -193,6 +221,7 @@ Initial inheritance rules:
 - Project conversations, files, artifacts, and memories inherit from their project.
 - File-derived artifacts inherit from the source file.
 - Memories may be persona-scoped, project-scoped, conversation-scoped, global, or directly shared.
+- User profiles do not inherit from conversations, projects, or memories. They inherit only from tenant policy and explicit access-control entries.
 
 Resource tables should keep enough owner and provenance fields to explain why a resource appears in context.
 
@@ -200,22 +229,22 @@ Resource tables should keep enough owner and provenance fields to explain why a 
 
 Diagnostics should answer: who can see this, why, and where did the access come from?
 
-API output should include the effective decision, owner fields, visibility, direct ACEs, inherited ACEs, group and role membership used, tenant policy defaults, and audit event references when available.
+API output should include the effective decision, owner fields, visibility, direct ACEs, inherited ACEs, group and role membership used, tenant policy defaults, persona `use_in_context` results, and audit event references when available.
 
-The UI should present this as a compact inspection panel for a selected conversation, memory, file, artifact, or project. It should not require users to understand table internals.
+The UI should present this as a compact inspection panel for a selected conversation, memory, file, artifact, project, or user profile. It should not require users to understand table internals.
 
 ## 12. Issue Mapping
 
 - #3 adds `audit_events` schema and audit logging helpers.
-- #4 adds owner and provenance fields to shareable resources.
+- #4 adds owner and provenance fields to shareable resources, including user profiles when that table is present.
 - #5 adds generic access-control entries.
 - #6 adds tenant-scoped groups and roles.
 - #7 adds TOML policy defaults and resolver hooks.
 - #8 adds the central access resolver with explain output.
 - #9 updates conversations and messages for ownership, persona identity, and inherited access.
-- #10 updates memories for persona assignment and persona-context access.
+- #10 updates memories for persona assignment and persona-context access while keeping About You in user profiles.
 - #11 updates files, artifacts, and projects for inherited sharing and ownership metadata.
-- #12 adds effective sharing diagnostics API and UI.
+- #12 adds effective sharing diagnostics API and UI, including user profile diagnostics and persona context explanations.
 
 ## 13. Compatibility Notes
 

--- a/server/access_control.py
+++ b/server/access_control.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from .config import TenantPolicyConfig, resolve_tenant_policy
+from .db_helpers import db_session, list_access_control_entries
+
+
+@dataclass(frozen=True)
+class PrincipalContext:
+    principal_type: str
+    principal_id: str
+    tenant_id: str = "default"
+    groups: tuple[str, ...] = ()
+    roles: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ResourceRef:
+    resource_type: str
+    resource_id: str
+    tenant_id: str = "default"
+    owner_principal_type: str | None = None
+    owner_principal_id: str | None = None
+    visibility: str | None = None
+    inherited_from: tuple[dict[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class AccessDecision:
+    allowed: bool
+    effect: str
+    reason: str
+    matched_entries: list[dict] = field(default_factory=list)
+    inherited_from: list[dict] = field(default_factory=list)
+    policy: dict = field(default_factory=dict)
+    explain: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _clean(value: Any, default: str = "") -> str:
+    cleaned = str(value or "").strip()
+    return cleaned or default
+
+
+def _parse_principal(principal: PrincipalContext | dict[str, Any]) -> PrincipalContext:
+    if isinstance(principal, PrincipalContext):
+        return principal
+    groups = principal.get("groups") or ()
+    roles = principal.get("roles") or ()
+    return PrincipalContext(
+        principal_type=_clean(principal.get("principal_type") or principal.get("type"), "user"),
+        principal_id=_clean(principal.get("principal_id") or principal.get("id"), "local"),
+        tenant_id=_clean(principal.get("tenant_id"), "default"),
+        groups=tuple(_clean(g) for g in groups if _clean(g)),
+        roles=tuple(_clean(r) for r in roles if _clean(r)),
+    )
+
+
+def _parse_resource(resource: ResourceRef | dict[str, Any]) -> ResourceRef:
+    if isinstance(resource, ResourceRef):
+        return resource
+    inherited = resource.get("inherited_from") or ()
+    return ResourceRef(
+        resource_type=_clean(resource.get("resource_type") or resource.get("type")),
+        resource_id=_clean(resource.get("resource_id") or resource.get("id")),
+        tenant_id=_clean(resource.get("tenant_id"), "default"),
+        owner_principal_type=_clean(resource.get("owner_principal_type")) or None,
+        owner_principal_id=_clean(resource.get("owner_principal_id")) or None,
+        visibility=_clean(resource.get("visibility")) or None,
+        inherited_from=tuple(
+            {
+                "resource_type": _clean(item.get("resource_type") or item.get("type")),
+                "resource_id": _clean(item.get("resource_id") or item.get("id")),
+            }
+            for item in inherited
+            if isinstance(item, dict) and _clean(item.get("resource_type") or item.get("type")) and _clean(item.get("resource_id") or item.get("id"))
+        ),
+    )
+
+
+def _principal_targets(principal: PrincipalContext) -> set[tuple[str, str]]:
+    targets = {(principal.principal_type, principal.principal_id), ("public", "*")}
+    targets.update(("group", group_id) for group_id in principal.groups)
+    targets.update(("role", role_id) for role_id in principal.roles)
+    return targets
+
+
+def _is_expired(row: dict, now: datetime) -> bool:
+    raw = _clean(row.get("expires_at"))
+    if not raw:
+        return False
+    try:
+        expires = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if expires.tzinfo is None:
+        expires = expires.replace(tzinfo=timezone.utc)
+    return expires <= now
+
+
+def _row_matches_principal(row: dict, targets: set[tuple[str, str]]) -> bool:
+    return (_clean(row.get("principal_type")), _clean(row.get("principal_id"))) in targets
+
+
+def _policy_dict(policy: TenantPolicyConfig) -> dict:
+    return asdict(policy)
+
+
+def _visibility_for(resource: ResourceRef, policy: TenantPolicyConfig) -> str:
+    if resource.visibility:
+        return resource.visibility
+    field_name = f"{resource.resource_type}_visibility"
+    return getattr(policy, field_name, "private")
+
+
+def _fetch_entries(conn, resource: ResourceRef, action: str, inherited: bool) -> list[dict]:
+    entries = list_access_control_entries(
+        conn=conn,
+        tenant_id=resource.tenant_id,
+        resource_type=resource.resource_type,
+        resource_id=resource.resource_id,
+        action=action,
+    )
+    for row in entries:
+        row["_inherited"] = inherited
+    return entries
+
+
+def resolve_access(
+    principal: PrincipalContext | dict[str, Any],
+    resource: ResourceRef | dict[str, Any],
+    action: str,
+    *,
+    explain: bool = False,
+    conn=None,
+    tenant_policy: TenantPolicyConfig | None = None,
+) -> AccessDecision:
+    principal_ctx = _parse_principal(principal)
+    resource_ref = _parse_resource(resource)
+    action = _clean(action, "read")
+    tenant_id = resource_ref.tenant_id or principal_ctx.tenant_id or "default"
+    resource_ref = ResourceRef(**{**asdict(resource_ref), "tenant_id": tenant_id})
+    policy = tenant_policy or resolve_tenant_policy(tenant_id)
+    notes: list[str] = []
+
+    def note(message: str) -> None:
+        if explain:
+            notes.append(message)
+
+    targets = _principal_targets(principal_ctx)
+    note(f"principal targets: {sorted(targets)}")
+    note(f"resource: {resource_ref.resource_type}:{resource_ref.resource_id} action={action} tenant={tenant_id}")
+
+    def _resolve(active_conn) -> AccessDecision:
+        now = datetime.now(timezone.utc)
+        direct_entries = _fetch_entries(active_conn, resource_ref, action, inherited=False)
+        inherited_entries: list[dict] = []
+        for parent in resource_ref.inherited_from:
+            parent_ref = ResourceRef(
+                resource_type=parent["resource_type"],
+                resource_id=parent["resource_id"],
+                tenant_id=tenant_id,
+            )
+            inherited_entries.extend(_fetch_entries(active_conn, parent_ref, action, inherited=True))
+
+        entries = [row for row in direct_entries + inherited_entries if not _is_expired(row, now)]
+        matching = [row for row in entries if _row_matches_principal(row, targets)]
+        note(f"matched ACEs: {len(matching)}")
+
+        denies = [row for row in matching if row.get("effect") == "deny"]
+        if denies:
+            note("deny ACE wins")
+            return AccessDecision(
+                allowed=False,
+                effect="deny",
+                reason="matched deny access-control entry",
+                matched_entries=denies,
+                inherited_from=[row for row in denies if row.get("_inherited")],
+                policy=_policy_dict(policy),
+                explain=notes,
+            )
+
+        if (
+            resource_ref.owner_principal_type
+            and resource_ref.owner_principal_id
+            and (resource_ref.owner_principal_type, resource_ref.owner_principal_id) in targets
+        ):
+            note("owner principal matched")
+            return AccessDecision(
+                allowed=True,
+                effect="allow",
+                reason="resource owner",
+                matched_entries=[],
+                inherited_from=[],
+                policy=_policy_dict(policy),
+                explain=notes,
+            )
+
+        allows = [row for row in matching if row.get("effect") == "allow"]
+        if allows:
+            note("allow ACE matched")
+            return AccessDecision(
+                allowed=True,
+                effect="allow",
+                reason="matched allow access-control entry",
+                matched_entries=allows,
+                inherited_from=[row for row in allows if row.get("_inherited")],
+                policy=_policy_dict(policy),
+                explain=notes,
+            )
+
+        visibility = _visibility_for(resource_ref, policy)
+        note(f"visibility fallback: {visibility}")
+        if action == "read" and visibility == "public" and policy.public_sharing_enabled:
+            return AccessDecision(True, "allow", "public visibility", [], [], _policy_dict(policy), notes)
+        if action == "read" and visibility == "tenant" and principal_ctx.tenant_id == tenant_id:
+            return AccessDecision(True, "allow", "tenant visibility", [], [], _policy_dict(policy), notes)
+        if policy.missing_access_default == "single_user_compatible":
+            return AccessDecision(True, "allow", "single-user compatibility default", [], [], _policy_dict(policy), notes)
+        if policy.missing_access_default == "allow_tenant" and principal_ctx.tenant_id == tenant_id:
+            return AccessDecision(True, "allow", "tenant policy default", [], [], _policy_dict(policy), notes)
+
+        return AccessDecision(False, "deny", "no matching access rule", [], [], _policy_dict(policy), notes)
+
+    if conn is not None:
+        return _resolve(conn)
+    with db_session() as active_conn:
+        return _resolve(active_conn)

--- a/server/access_control.py
+++ b/server/access_control.py
@@ -7,6 +7,18 @@ from typing import Any
 from .config import TenantPolicyConfig, resolve_tenant_policy
 from .db_helpers import db_session, list_access_control_entries
 
+_ACTION_ALIASES = {
+    "read": ("read", "view"),
+    "view": ("view", "read"),
+    "write": ("write", "edit"),
+    "edit": ("edit", "write"),
+    "delete": ("delete", "soft_remove"),
+    "soft_remove": ("soft_remove", "delete"),
+    "admin": ("admin", "manage"),
+    "manage": ("manage", "admin"),
+    "use_in_context": ("use_in_context",),
+}
+
 
 @dataclass(frozen=True)
 class PrincipalContext:
@@ -85,9 +97,75 @@ def _parse_resource(resource: ResourceRef | dict[str, Any]) -> ResourceRef:
 
 def _principal_targets(principal: PrincipalContext) -> set[tuple[str, str]]:
     targets = {(principal.principal_type, principal.principal_id), ("public", "*")}
+    if principal.principal_type == "user":
+        targets.add(("tenant_users", "*"))
+    if principal.principal_type == "persona":
+        targets.add(("tenant_personas", "*"))
     targets.update(("group", group_id) for group_id in principal.groups)
     targets.update(("role", role_id) for role_id in principal.roles)
     return targets
+
+
+def _action_candidates(action: str) -> tuple[str, ...]:
+    cleaned = _clean(action, "read").lower()
+    return _ACTION_ALIASES.get(cleaned, (cleaned,))
+
+
+def _role_matches(principal: PrincipalContext, role_name: str) -> bool:
+    role_name = role_name.strip().lower()
+    for role in principal.roles:
+        cleaned = role.strip().lower()
+        if cleaned == role_name or cleaned.endswith(f":{role_name}"):
+            return True
+    return False
+
+
+def _with_derived_memberships(conn, principal: PrincipalContext) -> PrincipalContext:
+    groups = set(principal.groups)
+    roles = set(principal.roles)
+    try:
+        group_rows = conn.execute(
+            """
+            SELECT group_id
+            FROM identity_group_members
+            WHERE tenant_id = ?
+              AND member_principal_type = ?
+              AND member_principal_id = ?
+              AND is_deleted = 0
+              AND (expires_at IS NULL OR TRIM(expires_at) = '' OR expires_at > CURRENT_TIMESTAMP)
+            """,
+            (principal.tenant_id, principal.principal_type, principal.principal_id),
+        ).fetchall()
+        groups.update(str(row["group_id"]) for row in group_rows)
+
+        role_rows = conn.execute(
+            """
+            SELECT ra.role_id, r.name
+            FROM identity_role_assignments ra
+            LEFT JOIN identity_roles r ON r.id = ra.role_id
+            WHERE ra.tenant_id IN (?, 'global')
+              AND ra.is_deleted = 0
+              AND (ra.expires_at IS NULL OR TRIM(ra.expires_at) = '' OR ra.expires_at > CURRENT_TIMESTAMP)
+              AND (
+                (ra.principal_type = ? AND ra.principal_id = ?)
+                OR (ra.principal_type = 'group' AND ra.principal_id IN (%s))
+              )
+            """ % (",".join("?" for _ in groups) or "''"),
+            (principal.tenant_id, principal.principal_type, principal.principal_id, *groups),
+        ).fetchall()
+        for row in role_rows:
+            roles.add(str(row["role_id"]))
+            if row["name"]:
+                roles.add(str(row["name"]))
+    except Exception:
+        return principal
+    return PrincipalContext(
+        principal_type=principal.principal_type,
+        principal_id=principal.principal_id,
+        tenant_id=principal.tenant_id,
+        groups=tuple(sorted(groups)),
+        roles=tuple(sorted(roles)),
+    )
 
 
 def _is_expired(row: dict, now: datetime) -> bool:
@@ -119,16 +197,48 @@ def _visibility_for(resource: ResourceRef, policy: TenantPolicyConfig) -> str:
 
 
 def _fetch_entries(conn, resource: ResourceRef, action: str, inherited: bool) -> list[dict]:
-    entries = list_access_control_entries(
-        conn=conn,
-        tenant_id=resource.tenant_id,
-        resource_type=resource.resource_type,
-        resource_id=resource.resource_id,
-        action=action,
-    )
-    for row in entries:
-        row["_inherited"] = inherited
+    entries: list[dict] = []
+    seen: set[str] = set()
+    for candidate in _action_candidates(action):
+        for row in list_access_control_entries(
+            conn=conn,
+            tenant_id=resource.tenant_id,
+            resource_type=resource.resource_type,
+            resource_id=resource.resource_id,
+            action=candidate,
+        ):
+            row_id = _clean(row.get("id"))
+            if row_id in seen:
+                continue
+            seen.add(row_id)
+            row["_inherited"] = inherited
+            entries.append(row)
     return entries
+
+
+def _admin_decision(principal: PrincipalContext, action: str, policy: TenantPolicyConfig, notes: list[str]) -> AccessDecision | None:
+    action = _clean(action, "read").lower()
+    if _role_matches(principal, "global_admin") and policy.global_admin_manage_all:
+        notes.append("global_admin policy matched")
+        return AccessDecision(True, "allow", "global admin policy", [], [], _policy_dict(policy), notes)
+    if _role_matches(principal, "tenant_admin") and policy.tenant_admin_manage_all:
+        if action == "permanent_remove" and not policy.tenant_admin_can_permanent_remove:
+            notes.append("tenant_admin permanent_remove denied by policy")
+            return AccessDecision(False, "deny", "tenant admin permanent remove disabled", [], [], _policy_dict(policy), notes)
+        notes.append("tenant_admin policy matched")
+        return AccessDecision(True, "allow", "tenant admin policy", [], [], _policy_dict(policy), notes)
+    return None
+
+
+def _owner_policy_denial(action: str, policy: TenantPolicyConfig) -> str | None:
+    action = _clean(action, "read").lower()
+    if action == "archive" and not policy.owner_can_archive:
+        return "owner archive disabled by tenant policy"
+    if action in {"soft_remove", "delete"} and not policy.owner_can_soft_remove:
+        return "owner soft remove disabled by tenant policy"
+    if action == "permanent_remove" and not policy.owner_can_permanent_remove:
+        return "owner permanent remove disabled by tenant policy"
+    return None
 
 
 def resolve_access(
@@ -142,7 +252,9 @@ def resolve_access(
 ) -> AccessDecision:
     principal_ctx = _parse_principal(principal)
     resource_ref = _parse_resource(resource)
-    action = _clean(action, "read")
+    action = _clean(action, "read").lower()
+    if principal_ctx.principal_type == "persona" and action == "read" and resource_ref.resource_type in {"memory", "user_profile"}:
+        action = "use_in_context"
     tenant_id = resource_ref.tenant_id or principal_ctx.tenant_id or "default"
     resource_ref = ResourceRef(**{**asdict(resource_ref), "tenant_id": tenant_id})
     policy = tenant_policy or resolve_tenant_policy(tenant_id)
@@ -152,11 +264,13 @@ def resolve_access(
         if explain:
             notes.append(message)
 
-    targets = _principal_targets(principal_ctx)
-    note(f"principal targets: {sorted(targets)}")
     note(f"resource: {resource_ref.resource_type}:{resource_ref.resource_id} action={action} tenant={tenant_id}")
 
     def _resolve(active_conn) -> AccessDecision:
+        nonlocal principal_ctx
+        principal_ctx = _with_derived_memberships(active_conn, principal_ctx)
+        targets = _principal_targets(principal_ctx)
+        note(f"principal targets: {sorted(targets)}")
         now = datetime.now(timezone.utc)
         direct_entries = _fetch_entries(active_conn, resource_ref, action, inherited=False)
         inherited_entries: list[dict] = []
@@ -184,6 +298,19 @@ def resolve_access(
                 policy=_policy_dict(policy),
                 explain=notes,
             )
+
+        admin = _admin_decision(principal_ctx, action, policy, notes)
+        if admin is not None:
+            return admin
+
+        owner_denial = _owner_policy_denial(action, policy)
+        if owner_denial and (
+            resource_ref.owner_principal_type
+            and resource_ref.owner_principal_id
+            and (resource_ref.owner_principal_type, resource_ref.owner_principal_id) in targets
+        ):
+            note(owner_denial)
+            return AccessDecision(False, "deny", owner_denial, [], [], _policy_dict(policy), notes)
 
         if (
             resource_ref.owner_principal_type
@@ -216,9 +343,9 @@ def resolve_access(
 
         visibility = _visibility_for(resource_ref, policy)
         note(f"visibility fallback: {visibility}")
-        if action == "read" and visibility == "public" and policy.public_sharing_enabled:
+        if action in {"read", "view"} and visibility == "public" and policy.public_sharing_enabled:
             return AccessDecision(True, "allow", "public visibility", [], [], _policy_dict(policy), notes)
-        if action == "read" and visibility == "tenant" and principal_ctx.tenant_id == tenant_id:
+        if action in {"read", "view"} and visibility == "tenant" and principal_ctx.tenant_id == tenant_id:
             return AccessDecision(True, "allow", "tenant visibility", [], [], _policy_dict(policy), notes)
         if policy.missing_access_default == "single_user_compatible":
             return AccessDecision(True, "allow", "single-user compatibility default", [], [], _policy_dict(policy), notes)

--- a/server/api_models.py
+++ b/server/api_models.py
@@ -106,7 +106,9 @@ class MemoryCreate(BaseModel):
     scope_type: str = "global"
     scope_id: int | None = None
     persona_id: str | None = None
-    persona_context_mode: str = "inherit"
+    persona_ids: list[str] | None = None
+    persona_scope: str | None = None
+    persona_context_mode: str = "include"
 
 class MemoryUpdate(BaseModel):
     content: str
@@ -117,6 +119,8 @@ class MemoryUpdate(BaseModel):
     scope_type: str | None = None
     scope_id: int | None = None
     persona_id: str | None = None
+    persona_ids: list[str] | None = None
+    persona_scope: str | None = None
     persona_context_mode: str | None = None
 
 class PinRequest(BaseModel):

--- a/server/api_models.py
+++ b/server/api_models.py
@@ -105,6 +105,8 @@ class MemoryCreate(BaseModel):
     origin_kind: str = "user_asserted"
     scope_type: str = "global"
     scope_id: int | None = None
+    persona_id: str | None = None
+    persona_context_mode: str = "inherit"
 
 class MemoryUpdate(BaseModel):
     content: str
@@ -114,6 +116,8 @@ class MemoryUpdate(BaseModel):
     origin_kind: str = "user_asserted"
     scope_type: str | None = None
     scope_id: int | None = None
+    persona_id: str | None = None
+    persona_context_mode: str | None = None
 
 class PinRequest(BaseModel):
     text: str

--- a/server/config.py
+++ b/server/config.py
@@ -1,5 +1,5 @@
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -320,6 +320,10 @@ def _cfg_csv_set(*paths: tuple[str, ...], env_name: str, default: str, allowed: 
         return _normalize_csv_set(raw, allowed)
     return _normalize_csv_set(_env_str(env_name, default), allowed)
 
+def _choice(value: Any, default: str, allowed: set[str]) -> str:
+    cleaned = str(value or "").strip().lower()
+    return cleaned if cleaned in allowed else default
+
 
 @dataclass(frozen=True)
 class CoreConfig:
@@ -563,6 +567,28 @@ class ToolConfig:
 TOOLS_DEFAULTS: ToolConfig = ToolConfig()
 
 
+@dataclass(frozen=True)
+class TenantPolicyConfig:
+    tenant_id: str = "default"
+    conversation_visibility: str = "private"
+    message_visibility: str = "private"
+    memory_visibility: str = "private"
+    file_visibility: str = "private"
+    artifact_visibility: str = "private"
+    project_visibility: str = "private"
+    public_sharing_enabled: bool = False
+    persona_resource_owner: str = "active_user"
+    missing_access_default: str = "allow_owner"
+    audit_verbosity: str = "mutations"
+
+
+TENANT_POLICY_DEFAULTS: TenantPolicyConfig = TenantPolicyConfig()
+TENANT_POLICY_VISIBILITY_ALLOWED = {"private", "tenant", "public", "inherit"}
+TENANT_POLICY_OWNER_ALLOWED = {"persona", "active_user", "tenant"}
+TENANT_POLICY_MISSING_ACCESS_ALLOWED = {"allow_owner", "allow_tenant", "deny", "single_user_compatible"}
+TENANT_POLICY_AUDIT_ALLOWED = {"off", "mutations", "decisions", "verbose"}
+
+
 @dataclass
 class AppConfig:
     search_chat_history: bool = True
@@ -603,6 +629,118 @@ def load_app_config() -> AppConfig:
     return AppConfig(
         search_chat_history=get_app_setting_bool(APP_KEYS.search_chat_history)
     )
+
+def _tenant_policy_from_mapping(base: TenantPolicyConfig, raw: dict[str, Any]) -> TenantPolicyConfig:
+    if not raw:
+        return base
+
+    visibility = raw.get("visibility_defaults")
+    updates: dict[str, Any] = {}
+
+    if "tenant_id" in raw or "default_tenant_id" in raw:
+        updates["tenant_id"] = str(raw.get("tenant_id", raw.get("default_tenant_id", base.tenant_id))).strip() or base.tenant_id
+    if isinstance(visibility, dict):
+        for key, field_name in (
+            ("conversation", "conversation_visibility"),
+            ("message", "message_visibility"),
+            ("memory", "memory_visibility"),
+            ("file", "file_visibility"),
+            ("artifact", "artifact_visibility"),
+            ("project", "project_visibility"),
+        ):
+            if key in visibility:
+                updates[field_name] = _choice(visibility[key], getattr(base, field_name), TENANT_POLICY_VISIBILITY_ALLOWED)
+
+    for key, allowed in (
+        ("persona_resource_owner", TENANT_POLICY_OWNER_ALLOWED),
+        ("missing_access_default", TENANT_POLICY_MISSING_ACCESS_ALLOWED),
+        ("audit_verbosity", TENANT_POLICY_AUDIT_ALLOWED),
+    ):
+        if key in raw:
+            updates[key] = _choice(raw[key], getattr(base, key), allowed)
+    if "public_sharing_enabled" in raw:
+        updates["public_sharing_enabled"] = _coerce_bool(raw["public_sharing_enabled"], base.public_sharing_enabled)
+
+    return replace(base, **updates)
+
+def load_tenant_policy_config(tenant_id: str | None = None) -> TenantPolicyConfig:
+    policy = TenantPolicyConfig(
+        tenant_id=_cfg_str(
+            ("tenant_policy", "default_tenant_id"),
+            env_name="TENANT_POLICY_DEFAULT_TENANT_ID",
+            default=TENANT_POLICY_DEFAULTS.tenant_id,
+        ),
+        conversation_visibility=_choice(
+            _first_toml(("tenant_policy", "visibility_defaults", "conversation"), default=TENANT_POLICY_DEFAULTS.conversation_visibility),
+            TENANT_POLICY_DEFAULTS.conversation_visibility,
+            TENANT_POLICY_VISIBILITY_ALLOWED,
+        ),
+        message_visibility=_choice(
+            _first_toml(("tenant_policy", "visibility_defaults", "message"), default=TENANT_POLICY_DEFAULTS.message_visibility),
+            TENANT_POLICY_DEFAULTS.message_visibility,
+            TENANT_POLICY_VISIBILITY_ALLOWED,
+        ),
+        memory_visibility=_choice(
+            _first_toml(("tenant_policy", "visibility_defaults", "memory"), default=TENANT_POLICY_DEFAULTS.memory_visibility),
+            TENANT_POLICY_DEFAULTS.memory_visibility,
+            TENANT_POLICY_VISIBILITY_ALLOWED,
+        ),
+        file_visibility=_choice(
+            _first_toml(("tenant_policy", "visibility_defaults", "file"), default=TENANT_POLICY_DEFAULTS.file_visibility),
+            TENANT_POLICY_DEFAULTS.file_visibility,
+            TENANT_POLICY_VISIBILITY_ALLOWED,
+        ),
+        artifact_visibility=_choice(
+            _first_toml(("tenant_policy", "visibility_defaults", "artifact"), default=TENANT_POLICY_DEFAULTS.artifact_visibility),
+            TENANT_POLICY_DEFAULTS.artifact_visibility,
+            TENANT_POLICY_VISIBILITY_ALLOWED,
+        ),
+        project_visibility=_choice(
+            _first_toml(("tenant_policy", "visibility_defaults", "project"), default=TENANT_POLICY_DEFAULTS.project_visibility),
+            TENANT_POLICY_DEFAULTS.project_visibility,
+            TENANT_POLICY_VISIBILITY_ALLOWED,
+        ),
+        public_sharing_enabled=_cfg_bool(
+            ("tenant_policy", "public_sharing_enabled"),
+            env_name="TENANT_POLICY_PUBLIC_SHARING_ENABLED",
+            default=TENANT_POLICY_DEFAULTS.public_sharing_enabled,
+        ),
+        persona_resource_owner=_choice(
+            _first_toml(("tenant_policy", "persona_resource_owner"), default=TENANT_POLICY_DEFAULTS.persona_resource_owner),
+            TENANT_POLICY_DEFAULTS.persona_resource_owner,
+            TENANT_POLICY_OWNER_ALLOWED,
+        ),
+        missing_access_default=_choice(
+            _first_toml(("tenant_policy", "missing_access_default"), default=TENANT_POLICY_DEFAULTS.missing_access_default),
+            TENANT_POLICY_DEFAULTS.missing_access_default,
+            TENANT_POLICY_MISSING_ACCESS_ALLOWED,
+        ),
+        audit_verbosity=_choice(
+            _first_toml(("tenant_policy", "audit_verbosity"), default=TENANT_POLICY_DEFAULTS.audit_verbosity),
+            TENANT_POLICY_DEFAULTS.audit_verbosity,
+            TENANT_POLICY_AUDIT_ALLOWED,
+        ),
+    )
+
+    target_tenant_id = (tenant_id or policy.tenant_id or TENANT_POLICY_DEFAULTS.tenant_id).strip() or TENANT_POLICY_DEFAULTS.tenant_id
+    policy = replace(policy, tenant_id=target_tenant_id)
+
+    tenant_override = _toml_get(("tenant_policy", "tenants", target_tenant_id), {})
+    if isinstance(tenant_override, dict):
+        policy = _tenant_policy_from_mapping(policy, tenant_override)
+        policy = replace(policy, tenant_id=target_tenant_id)
+    return policy
+
+def resolve_tenant_policy(
+    tenant_id: str | None = None,
+    overrides: dict[str, Any] | None = None,
+) -> TenantPolicyConfig:
+    policy = load_tenant_policy_config(tenant_id)
+    if overrides:
+        policy = _tenant_policy_from_mapping(policy, overrides)
+        if tenant_id:
+            policy = replace(policy, tenant_id=tenant_id.strip() or policy.tenant_id)
+    return policy
 
 
 def load_core_config() -> CoreConfig:

--- a/server/config.py
+++ b/server/config.py
@@ -570,6 +570,7 @@ TOOLS_DEFAULTS: ToolConfig = ToolConfig()
 @dataclass(frozen=True)
 class TenantPolicyConfig:
     tenant_id: str = "default"
+    policy_preset: str = "personal"
     conversation_visibility: str = "private"
     message_visibility: str = "private"
     memory_visibility: str = "private"
@@ -580,13 +581,67 @@ class TenantPolicyConfig:
     persona_resource_owner: str = "active_user"
     missing_access_default: str = "allow_owner"
     audit_verbosity: str = "mutations"
+    owner_can_archive: bool = True
+    owner_can_soft_remove: bool = True
+    owner_can_permanent_remove: bool = False
+    tenant_admin_manage_all: bool = True
+    global_admin_manage_all: bool = True
+    tenant_admin_can_permanent_remove: bool = False
+    retention_soft_delete_days: int = 30
+    retention_permanent_delete_days: int = 90
+    retention_audit_event_days: int = 365
 
 
 TENANT_POLICY_DEFAULTS: TenantPolicyConfig = TenantPolicyConfig()
+TENANT_POLICY_PRESET_ALLOWED = {"personal", "household", "corporate"}
 TENANT_POLICY_VISIBILITY_ALLOWED = {"private", "tenant", "public", "inherit"}
 TENANT_POLICY_OWNER_ALLOWED = {"persona", "active_user", "tenant"}
 TENANT_POLICY_MISSING_ACCESS_ALLOWED = {"allow_owner", "allow_tenant", "deny", "single_user_compatible"}
 TENANT_POLICY_AUDIT_ALLOWED = {"off", "mutations", "decisions", "verbose"}
+TENANT_POLICY_BUILTIN_PRESETS: dict[str, dict[str, Any]] = {
+    "personal": {
+        "missing_access_default": "allow_owner",
+        "owner_can_archive": True,
+        "owner_can_soft_remove": True,
+        "owner_can_permanent_remove": False,
+        "tenant_admin_manage_all": True,
+        "global_admin_manage_all": True,
+        "tenant_admin_can_permanent_remove": False,
+        "retention_windows": {
+            "soft_delete_days": 30,
+            "permanent_delete_days": 90,
+            "audit_event_days": 365,
+        },
+    },
+    "household": {
+        "missing_access_default": "allow_tenant",
+        "owner_can_archive": True,
+        "owner_can_soft_remove": True,
+        "owner_can_permanent_remove": False,
+        "tenant_admin_manage_all": True,
+        "global_admin_manage_all": True,
+        "tenant_admin_can_permanent_remove": False,
+        "retention_windows": {
+            "soft_delete_days": 45,
+            "permanent_delete_days": 120,
+            "audit_event_days": 365,
+        },
+    },
+    "corporate": {
+        "missing_access_default": "deny",
+        "owner_can_archive": True,
+        "owner_can_soft_remove": False,
+        "owner_can_permanent_remove": False,
+        "tenant_admin_manage_all": True,
+        "global_admin_manage_all": True,
+        "tenant_admin_can_permanent_remove": True,
+        "retention_windows": {
+            "soft_delete_days": 90,
+            "permanent_delete_days": 365,
+            "audit_event_days": 2555,
+        },
+    },
+}
 
 
 @dataclass
@@ -630,6 +685,15 @@ def load_app_config() -> AppConfig:
         search_chat_history=get_app_setting_bool(APP_KEYS.search_chat_history)
     )
 
+def _apply_tenant_policy_preset(policy: TenantPolicyConfig, preset_name: str | None) -> TenantPolicyConfig:
+    selected = _choice(preset_name, policy.policy_preset, TENANT_POLICY_PRESET_ALLOWED)
+    preset = _tenant_policy_from_mapping(policy, TENANT_POLICY_BUILTIN_PRESETS.get(selected, {}))
+    toml_preset = _toml_get(("tenant_policy", "presets", selected), {})
+    if isinstance(toml_preset, dict):
+        preset = _tenant_policy_from_mapping(preset, toml_preset)
+    return replace(preset, policy_preset=selected)
+
+
 def _tenant_policy_from_mapping(base: TenantPolicyConfig, raw: dict[str, Any]) -> TenantPolicyConfig:
     if not raw:
         return base
@@ -639,6 +703,8 @@ def _tenant_policy_from_mapping(base: TenantPolicyConfig, raw: dict[str, Any]) -
 
     if "tenant_id" in raw or "default_tenant_id" in raw:
         updates["tenant_id"] = str(raw.get("tenant_id", raw.get("default_tenant_id", base.tenant_id))).strip() or base.tenant_id
+    if "policy_preset" in raw or "preset" in raw:
+        updates["policy_preset"] = _choice(raw.get("policy_preset", raw.get("preset")), base.policy_preset, TENANT_POLICY_PRESET_ALLOWED)
     if isinstance(visibility, dict):
         for key, field_name in (
             ("conversation", "conversation_visibility"),
@@ -661,6 +727,40 @@ def _tenant_policy_from_mapping(base: TenantPolicyConfig, raw: dict[str, Any]) -
     if "public_sharing_enabled" in raw:
         updates["public_sharing_enabled"] = _coerce_bool(raw["public_sharing_enabled"], base.public_sharing_enabled)
 
+    for key in (
+        "owner_can_archive",
+        "owner_can_soft_remove",
+        "owner_can_permanent_remove",
+        "tenant_admin_manage_all",
+        "global_admin_manage_all",
+        "tenant_admin_can_permanent_remove",
+    ):
+        if key in raw:
+            updates[key] = _coerce_bool(raw[key], getattr(base, key))
+
+    retention = raw.get("retention_windows")
+    if isinstance(retention, dict):
+        for key, field_name in (
+            ("soft_delete_days", "retention_soft_delete_days"),
+            ("permanent_delete_days", "retention_permanent_delete_days"),
+            ("audit_event_days", "retention_audit_event_days"),
+        ):
+            if key in retention:
+                try:
+                    updates[field_name] = max(0, int(retention[key]))
+                except (TypeError, ValueError):
+                    pass
+    for field_name in (
+        "retention_soft_delete_days",
+        "retention_permanent_delete_days",
+        "retention_audit_event_days",
+    ):
+        if field_name in raw:
+            try:
+                updates[field_name] = max(0, int(raw[field_name]))
+            except (TypeError, ValueError):
+                pass
+
     return replace(base, **updates)
 
 def load_tenant_policy_config(tenant_id: str | None = None) -> TenantPolicyConfig:
@@ -669,6 +769,11 @@ def load_tenant_policy_config(tenant_id: str | None = None) -> TenantPolicyConfi
             ("tenant_policy", "default_tenant_id"),
             env_name="TENANT_POLICY_DEFAULT_TENANT_ID",
             default=TENANT_POLICY_DEFAULTS.tenant_id,
+        ),
+        policy_preset=_choice(
+            _first_toml(("tenant_policy", "policy_preset"), ("tenant_policy", "preset"), default=TENANT_POLICY_DEFAULTS.policy_preset),
+            TENANT_POLICY_DEFAULTS.policy_preset,
+            TENANT_POLICY_PRESET_ALLOWED,
         ),
         conversation_visibility=_choice(
             _first_toml(("tenant_policy", "visibility_defaults", "conversation"), default=TENANT_POLICY_DEFAULTS.conversation_visibility),
@@ -720,6 +825,20 @@ def load_tenant_policy_config(tenant_id: str | None = None) -> TenantPolicyConfi
             TENANT_POLICY_DEFAULTS.audit_verbosity,
             TENANT_POLICY_AUDIT_ALLOWED,
         ),
+        owner_can_archive=_cfg_bool(("tenant_policy", "owner_can_archive"), env_name="TENANT_POLICY_OWNER_CAN_ARCHIVE", default=TENANT_POLICY_DEFAULTS.owner_can_archive),
+        owner_can_soft_remove=_cfg_bool(("tenant_policy", "owner_can_soft_remove"), env_name="TENANT_POLICY_OWNER_CAN_SOFT_REMOVE", default=TENANT_POLICY_DEFAULTS.owner_can_soft_remove),
+        owner_can_permanent_remove=_cfg_bool(("tenant_policy", "owner_can_permanent_remove"), env_name="TENANT_POLICY_OWNER_CAN_PERMANENT_REMOVE", default=TENANT_POLICY_DEFAULTS.owner_can_permanent_remove),
+        tenant_admin_manage_all=_cfg_bool(("tenant_policy", "tenant_admin_manage_all"), env_name="TENANT_POLICY_TENANT_ADMIN_MANAGE_ALL", default=TENANT_POLICY_DEFAULTS.tenant_admin_manage_all),
+        global_admin_manage_all=_cfg_bool(("tenant_policy", "global_admin_manage_all"), env_name="TENANT_POLICY_GLOBAL_ADMIN_MANAGE_ALL", default=TENANT_POLICY_DEFAULTS.global_admin_manage_all),
+        tenant_admin_can_permanent_remove=_cfg_bool(("tenant_policy", "tenant_admin_can_permanent_remove"), env_name="TENANT_POLICY_TENANT_ADMIN_CAN_PERMANENT_REMOVE", default=TENANT_POLICY_DEFAULTS.tenant_admin_can_permanent_remove),
+        retention_soft_delete_days=_cfg_int(("tenant_policy", "retention_windows", "soft_delete_days"), env_name="TENANT_POLICY_RETENTION_SOFT_DELETE_DAYS", default=TENANT_POLICY_DEFAULTS.retention_soft_delete_days),
+        retention_permanent_delete_days=_cfg_int(("tenant_policy", "retention_windows", "permanent_delete_days"), env_name="TENANT_POLICY_RETENTION_PERMANENT_DELETE_DAYS", default=TENANT_POLICY_DEFAULTS.retention_permanent_delete_days),
+        retention_audit_event_days=_cfg_int(("tenant_policy", "retention_windows", "audit_event_days"), env_name="TENANT_POLICY_RETENTION_AUDIT_EVENT_DAYS", default=TENANT_POLICY_DEFAULTS.retention_audit_event_days),
+    )
+
+    policy = _tenant_policy_from_mapping(
+        _apply_tenant_policy_preset(TenantPolicyConfig(), policy.policy_preset),
+        policy.__dict__,
     )
 
     target_tenant_id = (tenant_id or policy.tenant_id or TENANT_POLICY_DEFAULTS.tenant_id).strip() or TENANT_POLICY_DEFAULTS.tenant_id
@@ -727,6 +846,8 @@ def load_tenant_policy_config(tenant_id: str | None = None) -> TenantPolicyConfi
 
     tenant_override = _toml_get(("tenant_policy", "tenants", target_tenant_id), {})
     if isinstance(tenant_override, dict):
+        if "policy_preset" in tenant_override or "preset" in tenant_override:
+            policy = _apply_tenant_policy_preset(policy, str(tenant_override.get("policy_preset", tenant_override.get("preset"))))
         policy = _tenant_policy_from_mapping(policy, tenant_override)
         policy = replace(policy, tenant_id=target_tenant_id)
     return policy
@@ -737,6 +858,8 @@ def resolve_tenant_policy(
 ) -> TenantPolicyConfig:
     policy = load_tenant_policy_config(tenant_id)
     if overrides:
+        if "policy_preset" in overrides or "preset" in overrides:
+            policy = _apply_tenant_policy_preset(policy, str(overrides.get("policy_preset", overrides.get("preset"))))
         policy = _tenant_policy_from_mapping(policy, overrides)
         if tenant_id:
             policy = replace(policy, tenant_id=tenant_id.strip() or policy.tenant_id)

--- a/server/context.py
+++ b/server/context.py
@@ -25,7 +25,9 @@ from .db import (
     db_list_artifact_reading_sessions,
     list_artifact_reading_sessions_for_conversation,
     db_list_artifact_reading_steps,
+    db_get_conversation_access_resource,
 )
+from .access_control import resolve_access
 
 from .config import (
     CoreConfig, get_prompt, load_core_config,
@@ -1298,6 +1300,17 @@ def build_context(
     ) -> dict:
     ctx_cfg = ctx_cfg or load_context_config()
     ret_cfg = ret_cfg or load_retrieval_config()
+
+    access_resource = db_get_conversation_access_resource(conversation_id)
+    if access_resource:
+        principal = {
+            "principal_type": "user",
+            "principal_id": "local",
+            "tenant_id": access_resource.get("tenant_id") or "default",
+        }
+        decision = resolve_access(principal, access_resource, "read", explain=True)
+        if not decision.allowed:
+            raise PermissionError(f"Conversation access denied: {decision.reason}")
 
     # Do not lazily rebuild conversation transcript artifacts inside ordinary
     # context assembly. Read paths should stay read-mostly; explicit refresh

--- a/server/db.py
+++ b/server/db.py
@@ -30,6 +30,7 @@ from .db_helpers import (
     db_session, db_debug_info, _start_schema_init, _end_schema_init, 
     ensure_parent_dir, _table_exists, _add_column_if_missing,
     ensure_audit_events_schema, ensure_resource_ownership_columns,
+    ensure_access_control_schema,
 )
 # Support legacy migrations from v1-v7. You can remove this after a few releases once most users have migrated or started fresh.
 from .db_migrate import _migrate_schema_legacy
@@ -73,6 +74,9 @@ def _migrate_schema_v24(conn) -> None:
 def _migrate_schema_v25(conn) -> None:
     ensure_resource_ownership_columns(conn)
 
+def _migrate_schema_v26(conn) -> None:
+    ensure_access_control_schema(conn)
+
 
 MIGRATIONS: list[tuple[int, Callable]] = [
     (8, _migrate_schema_v8),
@@ -93,6 +97,7 @@ MIGRATIONS: list[tuple[int, Callable]] = [
     (23, _migrate_schema_v23),
     (24, _migrate_schema_v24),
     (25, _migrate_schema_v25),
+    (26, _migrate_schema_v26),
 ]
 
 # endregion

--- a/server/db.py
+++ b/server/db.py
@@ -31,6 +31,7 @@ from .db_helpers import (
     ensure_parent_dir, _table_exists, _add_column_if_missing,
     ensure_audit_events_schema, ensure_resource_ownership_columns,
     ensure_access_control_schema, ensure_identity_group_role_schema,
+    create_access_control_entry, list_access_control_entries, remove_access_control_entry,
 )
 # Support legacy migrations from v1-v7. You can remove this after a few releases once most users have migrated or started fresh.
 from .db_migrate import _migrate_schema_legacy
@@ -92,6 +93,24 @@ def _migrate_schema_v29(conn) -> None:
     ensure_resource_ownership_columns(conn)
 
 
+def _migrate_schema_v30(conn) -> None:
+    _add_column_if_missing(conn, "memories", "persona_scope", "TEXT NOT NULL DEFAULT 'tenant_all'")
+    _add_column_if_missing(conn, "memories", "persona_principal_ids_json", "TEXT")
+    conn.execute(
+        """
+        UPDATE memories
+        SET persona_scope = CASE
+            WHEN persona_principal_id IS NULL OR TRIM(persona_principal_id) = '' THEN 'tenant_all'
+            ELSE 'assigned'
+        END
+        WHERE persona_scope IS NULL OR TRIM(persona_scope) = ''
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memories_persona_scope ON memories(persona_scope)"
+    )
+
+
 MIGRATIONS: list[tuple[int, Callable]] = [
     (8, _migrate_schema_v8),
     (9, _migrate_schema_v9),
@@ -115,6 +134,7 @@ MIGRATIONS: list[tuple[int, Callable]] = [
     (27, _migrate_schema_v27),
     (28, _migrate_schema_v28),
     (29, _migrate_schema_v29),
+    (30, _migrate_schema_v30),
 ]
 
 # endregion
@@ -2577,6 +2597,69 @@ def db_update_ab_canonical(conversation_id: str, ab_group: str, slot: str) -> No
 
 # region Memories
 
+def _normalize_persona_scope(persona_scope: str | None, persona_id: str | None, persona_ids: list[str] | None) -> str:
+    scope = (persona_scope or "").strip().lower()
+    if scope in {"assigned", "selected", "tenant_all"}:
+        return scope
+    if persona_ids:
+        return "selected"
+    if persona_id:
+        return "assigned"
+    return "tenant_all"
+
+
+def _normalize_persona_ids(persona_ids: list[str] | tuple[str, ...] | None) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in persona_ids or []:
+        cleaned = str(value or "").strip()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            out.append(cleaned)
+    return out
+
+
+def _sync_memory_persona_access_entries(conn: sqlite3.Connection, mem: dict) -> None:
+    memory_id = str(mem["id"])
+    for row in list_access_control_entries(
+        conn=conn,
+        tenant_id=mem.get("tenant_id") or "default",
+        resource_type="memory",
+        resource_id=memory_id,
+        action="use_in_context",
+    ):
+        if row.get("principal_type") in {"persona", "tenant_personas"}:
+            remove_access_control_entry(row["id"], deleted_by_principal_type="service", deleted_by_principal_id="memory_persona_sync", conn=conn)
+
+    mode = (mem.get("persona_context_mode") or "inherit").strip().lower()
+    if mode == "exclude":
+        return
+    scope = (mem.get("persona_scope") or "tenant_all").strip().lower()
+    targets: list[tuple[str, str]] = []
+    if scope == "tenant_all":
+        targets.append(("tenant_personas", "*"))
+    elif scope == "selected":
+        targets.extend(("persona", pid) for pid in mem.get("persona_principal_ids") or [])
+    else:
+        pid = (mem.get("persona_principal_id") or "").strip()
+        if pid:
+            targets.append(("persona", pid))
+    for principal_type, principal_id in targets:
+        create_access_control_entry(
+            conn=conn,
+            tenant_id=mem.get("tenant_id") or "default",
+            resource_type="memory",
+            resource_id=memory_id,
+            principal_type=principal_type,
+            principal_id=principal_id,
+            effect="allow",
+            action="use_in_context",
+            created_by_principal_type="service",
+            created_by_principal_id="memory_persona_sync",
+            reason="memory persona scope",
+        )
+
+
 def _ensure_memory_exists(conn: sqlite3.Connection, memory_id: str) -> None:
     row = conn.execute("SELECT 1 FROM memories WHERE id = ?", (memory_id,)).fetchone()
     if not row:
@@ -2611,6 +2694,8 @@ def _memory_row_to_dict(row: sqlite3.Row) -> dict:
         "provenance_json": row["provenance_json"],
         "persona_principal_id": row["persona_principal_id"],
         "persona_context_mode": row["persona_context_mode"] or "inherit",
+        "persona_scope": row["persona_scope"] or "tenant_all",
+        "persona_principal_ids": json.loads(row["persona_principal_ids_json"] or "[]"),
         "project_ids": [int(x) for x in _split_csv(row["project_ids_csv"]) if str(x).isdigit()],
         "conversation_ids": _split_csv(row["conversation_ids_csv"]),
         "created_at": row["created_at"],
@@ -2642,6 +2727,8 @@ def _fetch_memory_row(conn: sqlite3.Connection, memory_id: str) -> dict:
             m.provenance_json,
             m.persona_principal_id,
             m.persona_context_mode,
+            m.persona_scope,
+            m.persona_principal_ids_json,
             m.created_at,
             m.updated_at,
             (
@@ -2677,6 +2764,8 @@ def db_add_memory(
     scope_id: int | None = None,
     persona_id: str | None = None,
     persona_context_mode: str = "inherit",
+    persona_ids: list[str] | None = None,
+    persona_scope: str | None = None,
     tenant_id: str | None = None,
 ) -> dict:
     content = (content or "").strip()
@@ -2691,7 +2780,9 @@ def db_add_memory(
     source_conversation_id = (source_conversation_id or "").strip() or None
     source_message_id = (source_message_id or "").strip() or None
     persona_id = (persona_id or "").strip() or None
-    persona_context_mode = (persona_context_mode or "inherit").strip().lower()
+    persona_ids = _normalize_persona_ids(persona_ids)
+    persona_scope = _normalize_persona_scope(persona_scope, persona_id, persona_ids)
+    persona_context_mode = (persona_context_mode or "include").strip().lower()
     if persona_context_mode not in ("inherit", "include", "exclude"):
         persona_context_mode = "inherit"
     policy = resolve_tenant_policy(tenant_id)
@@ -2736,10 +2827,12 @@ def db_add_memory(
                 provenance_json,
                 persona_principal_id,
                 persona_context_mode,
+                persona_scope,
+                persona_principal_ids_json,
                 created_at,
                 updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             mem_id,
             content,
@@ -2763,11 +2856,14 @@ def db_add_memory(
             json.dumps({"source_conversation_id": source_conversation_id, "source_message_id": source_message_id}, ensure_ascii=False, sort_keys=True),
             persona_id,
             persona_context_mode,
+            persona_scope,
+            json.dumps(persona_ids, ensure_ascii=False, sort_keys=True) if persona_ids else None,
             now,
             now,
         ))
 
         mem = _fetch_memory_row(conn, mem_id)
+        _sync_memory_persona_access_entries(conn, mem)
         artifact_id = _upsert_memory_artifact_for_row(conn, mem)
 
     try:
@@ -2810,6 +2906,8 @@ def db_list_memories(limit: int = 200) -> list[dict]:
                 m.provenance_json,
                 m.persona_principal_id,
                 m.persona_context_mode,
+                m.persona_scope,
+                m.persona_principal_ids_json,
                 m.created_at,
                 m.updated_at,
                 (
@@ -2846,6 +2944,8 @@ def db_update_memory(
     scope_id: int | None = None,
     persona_id: str | None = None,
     persona_context_mode: str | None = None,
+    persona_ids: list[str] | None = None,
+    persona_scope: str | None = None,
 ) -> dict:
     memory_id = (memory_id or "").strip()
     if not memory_id:
@@ -2859,6 +2959,8 @@ def db_update_memory(
     created_by = (created_by or "user").strip() or "user"
     origin_kind = (origin_kind or "user_asserted").strip() or "user_asserted"
     persona_id = (persona_id or "").strip() or None
+    persona_ids = _normalize_persona_ids(persona_ids)
+    persona_scope = _normalize_persona_scope(persona_scope, persona_id, persona_ids) if (persona_scope is not None or persona_id is not None or persona_ids) else None
     persona_context_mode = (persona_context_mode or "").strip().lower() or None
     if persona_context_mode is not None and persona_context_mode not in ("inherit", "include", "exclude"):
         persona_context_mode = "inherit"
@@ -2890,6 +2992,8 @@ def db_update_memory(
                 origin_kind = ?,
                 persona_principal_id = ?,
                 persona_context_mode = ?,
+                persona_scope = ?,
+                persona_principal_ids_json = ?,
                 updated_at = ?
             WHERE id = ?
         """, (
@@ -2902,11 +3006,14 @@ def db_update_memory(
             origin_kind,
             persona_id if persona_id is not None else existing.get("persona_principal_id"),
             persona_context_mode if persona_context_mode is not None else existing.get("persona_context_mode") or "inherit",
+            persona_scope if persona_scope is not None else existing.get("persona_scope") or "tenant_all",
+            json.dumps(persona_ids, ensure_ascii=False, sort_keys=True) if persona_ids else json.dumps(existing.get("persona_principal_ids") or [], ensure_ascii=False, sort_keys=True),
             now,
             memory_id,
         ))
 
         mem = _fetch_memory_row(conn, memory_id)
+        _sync_memory_persona_access_entries(conn, mem)
         artifact_id = _upsert_memory_artifact_for_row(conn, mem)
 
     try:
@@ -2983,6 +3090,8 @@ def db_get_memory_access_resource(memory_id: str) -> dict | None:
     }
 
 def db_list_memories_for_persona(persona_id: str, include_unassigned: bool = True, limit: int = 200) -> list[dict]:
+    from .access_control import resolve_access
+
     persona_id = (persona_id or "").strip()
     if not persona_id:
         return []
@@ -2991,9 +3100,29 @@ def db_list_memories_for_persona(persona_id: str, include_unassigned: bool = Tru
     for mem in memories:
         assigned = (mem.get("persona_principal_id") or "").strip()
         mode = (mem.get("persona_context_mode") or "inherit").strip().lower()
+        scope = (mem.get("persona_scope") or "tenant_all").strip().lower()
+        selected = set(mem.get("persona_principal_ids") or [])
         if mode == "exclude":
             continue
-        if assigned == persona_id or (include_unassigned and not assigned):
+        candidate = False
+        if scope == "tenant_all":
+            candidate = True
+        elif scope == "selected":
+            candidate = persona_id in selected
+        elif assigned == persona_id or (include_unassigned and not assigned):
+            candidate = True
+        if not candidate:
+            continue
+        resource = db_get_memory_access_resource(mem["id"])
+        if not resource:
+            continue
+        decision = resolve_access(
+            {"principal_type": "persona", "principal_id": persona_id, "tenant_id": mem.get("tenant_id") or "default"},
+            resource,
+            "use_in_context",
+            explain=False,
+        )
+        if decision.allowed:
             out.append(mem)
     return out
 
@@ -3071,6 +3200,8 @@ def _memory_artifact_meta(mem: dict) -> dict:
         "owner_principal_id": mem.get("owner_principal_id"),
         "persona_principal_id": mem.get("persona_principal_id"),
         "persona_context_mode": mem.get("persona_context_mode") or "inherit",
+        "persona_scope": mem.get("persona_scope") or "tenant_all",
+        "persona_principal_ids": mem.get("persona_principal_ids") or [],
     }
 
 def _upsert_memory_artifact_for_row(conn: sqlite3.Connection, mem: dict) -> str:

--- a/server/db.py
+++ b/server/db.py
@@ -18,7 +18,7 @@ from .logging_helper import log_debug
 from .config import (
     load_core_config, load_app_config, load_ui_config,
     RetrievalConfig, load_retrieval_config, 
-    load_import_config,
+    load_import_config, resolve_tenant_policy,
 )
 
 from .markdown_helper import autolink_text, apply_house_markdown_normalization
@@ -844,16 +844,132 @@ def _ensure_conversation_exists(conn: sqlite3.Connection, conversation_id: str) 
     if not row:
         raise ValueError(f"Conversation not found: {conversation_id}")
 
-def db_create_conversation(conversation_id: str, title: str = "New chat") -> None:
+def _principal_from_payload(
+    role: str,
+    meta: dict | None = None,
+    author_meta: dict | None = None,
+) -> tuple[str, str]:
+    payloads = [author_meta or {}, meta or {}]
+    for payload in payloads:
+        principal_type = (payload.get("principal_type") or payload.get("type") or "").strip()
+        principal_id = (payload.get("principal_id") or payload.get("id") or "").strip()
+        if principal_type and principal_id:
+            return principal_type, principal_id
+
+    role = (role or "").strip().lower()
+    if role == "assistant":
+        persona_id = ""
+        for payload in payloads:
+            persona_id = (
+                payload.get("persona_id")
+                or payload.get("deployment_id")
+                or payload.get("model")
+                or ""
+            ).strip()
+            if persona_id:
+                break
+        return "persona", persona_id or "assistant"
+    return "user", "local"
+
+def _conversation_access_resource_from_row(row: sqlite3.Row | dict) -> dict:
+    return {
+        "resource_type": "conversation",
+        "resource_id": row["id"],
+        "tenant_id": row["tenant_id"] or "default",
+        "owner_principal_type": row["owner_principal_type"],
+        "owner_principal_id": row["owner_principal_id"],
+        "visibility": row["visibility"],
+    }
+
+def db_get_conversation_access_resource(conversation_id: str) -> dict | None:
+    with db_session() as conn:
+        row = conn.execute(
+            """
+            SELECT id, tenant_id, owner_principal_type, owner_principal_id, visibility
+            FROM conversations
+            WHERE id = ?
+            """,
+            (conversation_id,),
+        ).fetchone()
+        return _conversation_access_resource_from_row(row) if row else None
+
+def db_get_message_access_resource(message_id: int) -> dict | None:
+    with db_session() as conn:
+        row = conn.execute(
+            """
+            SELECT
+                m.id,
+                m.conversation_id,
+                m.tenant_id,
+                m.owner_principal_type,
+                m.owner_principal_id,
+                m.visibility,
+                c.tenant_id AS conversation_tenant_id
+            FROM messages m
+            LEFT JOIN conversations c ON c.id = m.conversation_id
+            WHERE m.id = ?
+            """,
+            (int(message_id),),
+        ).fetchone()
+        if not row:
+            return None
+        tenant_id = row["tenant_id"] or row["conversation_tenant_id"] or "default"
+        return {
+            "resource_type": "message",
+            "resource_id": str(row["id"]),
+            "tenant_id": tenant_id,
+            "owner_principal_type": row["owner_principal_type"],
+            "owner_principal_id": row["owner_principal_id"],
+            "visibility": row["visibility"],
+            "inherited_from": [
+                {"resource_type": "conversation", "resource_id": row["conversation_id"]}
+            ],
+        }
+
+def db_create_conversation(
+    conversation_id: str,
+    title: str = "New chat",
+    *,
+    tenant_id: str | None = None,
+    owner_principal_type: str | None = None,
+    owner_principal_id: str | None = None,
+    created_by_principal_type: str | None = None,
+    created_by_principal_id: str | None = None,
+    visibility: str | None = None,
+    sharing_mode: str | None = None,
+    provenance: dict | None = None,
+) -> None:
     now = _utc_now_iso()
     title = (title or "").strip() or "New chat"
+    policy = resolve_tenant_policy(tenant_id)
+    tenant_id = (tenant_id or policy.tenant_id or "default").strip() or "default"
+    owner_principal_type = (owner_principal_type or "user").strip() or "user"
+    owner_principal_id = (owner_principal_id or "local").strip() or "local"
+    created_by_principal_type = (created_by_principal_type or owner_principal_type).strip() or owner_principal_type
+    created_by_principal_id = (created_by_principal_id or owner_principal_id).strip() or owner_principal_id
+    visibility = (visibility or policy.conversation_visibility or "private").strip() or "private"
+    sharing_mode = (sharing_mode or "owner").strip() or "owner"
+    provenance_json = json.dumps(provenance, ensure_ascii=False, sort_keys=True) if provenance else None
+
     with db_session() as conn:
         conn.execute(
             """
-            INSERT INTO conversations(id, title, created_at, updated_at)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO conversations(
+                id, title, created_at, updated_at, tenant_id,
+                owner_principal_type, owner_principal_id,
+                created_by_principal_type, created_by_principal_id,
+                source_principal_type, source_principal_id,
+                visibility, sharing_mode, provenance_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (conversation_id, title, now, now),
+            (
+                conversation_id, title, now, now, tenant_id,
+                owner_principal_type, owner_principal_id,
+                created_by_principal_type, created_by_principal_id,
+                created_by_principal_type, created_by_principal_id,
+                visibility, sharing_mode, provenance_json,
+            ),
         )
 
 def update_conversation_title(conversation_id: str, title: str) -> bool:
@@ -898,7 +1014,15 @@ def db_list_conversations(
                 c.project_id,
                 c.archived,
                 p.name AS project_name,
-                s.summary_text AS summary_text
+                s.summary_text AS summary_text,
+                c.tenant_id,
+                c.owner_principal_type,
+                c.owner_principal_id,
+                c.created_by_principal_type,
+                c.created_by_principal_id,
+                c.visibility,
+                c.sharing_mode,
+                c.provenance_json
             FROM conversations c
             LEFT JOIN projects p ON p.id = c.project_id
             LEFT JOIN artifacts s
@@ -924,6 +1048,14 @@ def db_list_conversations(
                 "is_unassigned_pseudo": r["project_id"] is None,
                 "archived": bool(r["archived"]),
                 "summary_excerpt": _summary_excerpt(r["summary_text"] or ""),
+                "tenant_id": r["tenant_id"] or "default",
+                "owner_principal_type": r["owner_principal_type"],
+                "owner_principal_id": r["owner_principal_id"],
+                "created_by_principal_type": r["created_by_principal_type"],
+                "created_by_principal_id": r["created_by_principal_id"],
+                "visibility": r["visibility"],
+                "sharing_mode": r["sharing_mode"],
+                "provenance_json": r["provenance_json"],
             }
             for r in rows
         ]
@@ -931,7 +1063,7 @@ def db_list_conversations(
 def db_set_conversation_project(conversation_id: str, project_id: int | None) -> None:
     with db_session() as conn:
         conn.execute(
-            "UPDATE conversations SET project_id = ?, updated_at = ? WHERE id = ?",
+            "UPDATE conversations SET project_id = ?, updated_at = ?, sharing_mode = COALESCE(sharing_mode, 'owner') WHERE id = ?",
             (project_id, _utc_now_iso(), conversation_id),
         )
 
@@ -2018,16 +2150,41 @@ def db_add_message(
     now = _utc_now_iso()
     meta_json = json.dumps(meta) if meta is not None else None
     author_meta_json = json.dumps(author_meta) if author_meta is not None else None
+    source_principal_type, source_principal_id = _principal_from_payload(role, meta, author_meta)
 
     new_message_id = 0
 
     with db_session() as conn:
+        conv = conn.execute(
+            """
+            SELECT tenant_id, owner_principal_type, owner_principal_id, visibility
+            FROM conversations
+            WHERE id = ?
+            """,
+            (conversation_id,),
+        ).fetchone()
+        tenant_id = (conv["tenant_id"] if conv else None) or "default"
+        owner_principal_type = (conv["owner_principal_type"] if conv else None) or source_principal_type
+        owner_principal_id = (conv["owner_principal_id"] if conv else None) or source_principal_id
         cur = conn.execute(
             """
-            INSERT INTO messages(conversation_id, role, content, created_at, meta, author_meta)
-            VALUES(?, ?, ?, ?, ?, ?)
+            INSERT INTO messages(
+                conversation_id, role, content, created_at, meta, author_meta,
+                tenant_id, owner_principal_type, owner_principal_id,
+                created_by_principal_type, created_by_principal_id,
+                source_principal_type, source_principal_id,
+                visibility, sharing_mode, provenance_json
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (conversation_id, role, content, now, meta_json, author_meta_json),
+            (
+                conversation_id, role, content, now, meta_json, author_meta_json,
+                tenant_id, owner_principal_type, owner_principal_id,
+                source_principal_type, source_principal_id,
+                source_principal_type, source_principal_id,
+                "inherit", "inherit",
+                json.dumps({"conversation_id": conversation_id}, ensure_ascii=False, sort_keys=True),
+            ),
         )
         new_message_id = int(cur.lastrowid or 0)
 
@@ -2064,7 +2221,12 @@ def db_get_messages_raw(conversation_id: str, limit: int = 200) -> list[dict]:
     with db_session() as conn:
         rows = conn.execute(
             """
-            SELECT id, role, content, created_at, meta, author_meta
+            SELECT
+                id, role, content, created_at, meta, author_meta,
+                tenant_id, owner_principal_type, owner_principal_id,
+                created_by_principal_type, created_by_principal_id,
+                source_principal_type, source_principal_id,
+                visibility, sharing_mode, provenance_json
             FROM messages
             WHERE conversation_id = ?
             ORDER BY id ASC
@@ -2098,6 +2260,17 @@ def db_get_messages_raw(conversation_id: str, limit: int = 200) -> list[dict]:
                 "created_at": r["created_at"],
                 "meta": meta_obj,
                 "author_meta": author_meta_obj,
+                "tenant_id": r["tenant_id"] or "default",
+                "owner_principal_type": r["owner_principal_type"],
+                "owner_principal_id": r["owner_principal_id"],
+                "created_by_principal_type": r["created_by_principal_type"],
+                "created_by_principal_id": r["created_by_principal_id"],
+                "source_principal_type": r["source_principal_type"],
+                "source_principal_id": r["source_principal_id"],
+                "visibility": r["visibility"],
+                "sharing_mode": r["sharing_mode"],
+                "provenance_json": r["provenance_json"],
+                "inherited_from": [{"resource_type": "conversation", "resource_id": conversation_id}],
             }
         )
     return results

--- a/server/db.py
+++ b/server/db.py
@@ -7464,9 +7464,7 @@ def db_delete_file_cascade(
             if p.exists() and p.is_file():
                 backup_root = DATA_DIR / "deleted_files"
                 backup_root.mkdir(parents=True, exist_ok=True)
-
-                # TODO fix deprecated function call
-                stamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+                stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
                 target = backup_root / f"{stamp}__{file_id}__{p.name}"
 
                 p.replace(target)

--- a/server/db.py
+++ b/server/db.py
@@ -30,7 +30,7 @@ from .db_helpers import (
     db_session, db_debug_info, _start_schema_init, _end_schema_init, 
     ensure_parent_dir, _table_exists, _add_column_if_missing,
     ensure_audit_events_schema, ensure_resource_ownership_columns,
-    ensure_access_control_schema,
+    ensure_access_control_schema, ensure_identity_group_role_schema,
 )
 # Support legacy migrations from v1-v7. You can remove this after a few releases once most users have migrated or started fresh.
 from .db_migrate import _migrate_schema_legacy
@@ -77,6 +77,9 @@ def _migrate_schema_v25(conn) -> None:
 def _migrate_schema_v26(conn) -> None:
     ensure_access_control_schema(conn)
 
+def _migrate_schema_v27(conn) -> None:
+    ensure_identity_group_role_schema(conn)
+
 
 MIGRATIONS: list[tuple[int, Callable]] = [
     (8, _migrate_schema_v8),
@@ -98,6 +101,7 @@ MIGRATIONS: list[tuple[int, Callable]] = [
     (24, _migrate_schema_v24),
     (25, _migrate_schema_v25),
     (26, _migrate_schema_v26),
+    (27, _migrate_schema_v27),
 ]
 
 # endregion

--- a/server/db.py
+++ b/server/db.py
@@ -80,6 +80,13 @@ def _migrate_schema_v26(conn) -> None:
 def _migrate_schema_v27(conn) -> None:
     ensure_identity_group_role_schema(conn)
 
+def _migrate_schema_v28(conn) -> None:
+    _add_column_if_missing(conn, "memories", "persona_principal_id", "TEXT")
+    _add_column_if_missing(conn, "memories", "persona_context_mode", "TEXT NOT NULL DEFAULT 'inherit'")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memories_persona_context ON memories(persona_principal_id, persona_context_mode)"
+    )
+
 
 MIGRATIONS: list[tuple[int, Callable]] = [
     (8, _migrate_schema_v8),
@@ -102,6 +109,7 @@ MIGRATIONS: list[tuple[int, Callable]] = [
     (25, _migrate_schema_v25),
     (26, _migrate_schema_v26),
     (27, _migrate_schema_v27),
+    (28, _migrate_schema_v28),
 ]
 
 # endregion
@@ -2359,6 +2367,18 @@ def _memory_row_to_dict(row: sqlite3.Row) -> dict:
         "origin_kind": row["origin_kind"] or "user_asserted",
         "source_conversation_id": row["source_conversation_id"],
         "source_message_id": row["source_message_id"],
+        "tenant_id": row["tenant_id"] or "default",
+        "owner_principal_type": row["owner_principal_type"],
+        "owner_principal_id": row["owner_principal_id"],
+        "created_by_principal_type": row["created_by_principal_type"],
+        "created_by_principal_id": row["created_by_principal_id"],
+        "source_principal_type": row["source_principal_type"],
+        "source_principal_id": row["source_principal_id"],
+        "visibility": row["visibility"],
+        "sharing_mode": row["sharing_mode"],
+        "provenance_json": row["provenance_json"],
+        "persona_principal_id": row["persona_principal_id"],
+        "persona_context_mode": row["persona_context_mode"] or "inherit",
         "project_ids": [int(x) for x in _split_csv(row["project_ids_csv"]) if str(x).isdigit()],
         "conversation_ids": _split_csv(row["conversation_ids_csv"]),
         "created_at": row["created_at"],
@@ -2378,6 +2398,18 @@ def _fetch_memory_row(conn: sqlite3.Connection, memory_id: str) -> dict:
             COALESCE(m.origin_kind, 'user_asserted') AS origin_kind,
             m.source_conversation_id,
             m.source_message_id,
+            m.tenant_id,
+            m.owner_principal_type,
+            m.owner_principal_id,
+            m.created_by_principal_type,
+            m.created_by_principal_id,
+            m.source_principal_type,
+            m.source_principal_id,
+            m.visibility,
+            m.sharing_mode,
+            m.provenance_json,
+            m.persona_principal_id,
+            m.persona_context_mode,
             m.created_at,
             m.updated_at,
             (
@@ -2411,6 +2443,9 @@ def db_add_memory(
     source_message_id: str | None = None,
     scope_type: str = "global",
     scope_id: int | None = None,
+    persona_id: str | None = None,
+    persona_context_mode: str = "inherit",
+    tenant_id: str | None = None,
 ) -> dict:
     content = (content or "").strip()
     if not content:
@@ -2423,6 +2458,18 @@ def db_add_memory(
     origin_kind = (origin_kind or "user_asserted").strip() or "user_asserted"
     source_conversation_id = (source_conversation_id or "").strip() or None
     source_message_id = (source_message_id or "").strip() or None
+    persona_id = (persona_id or "").strip() or None
+    persona_context_mode = (persona_context_mode or "inherit").strip().lower()
+    if persona_context_mode not in ("inherit", "include", "exclude"):
+        persona_context_mode = "inherit"
+    policy = resolve_tenant_policy(tenant_id)
+    tenant_id = (tenant_id or policy.tenant_id or "default").strip() or "default"
+    source_principal_type = "persona" if persona_id else ("persona" if created_by == "assistant" else "user")
+    source_principal_id = persona_id or ("assistant" if source_principal_type == "persona" else "local")
+    if policy.persona_resource_owner == "persona" and persona_id:
+        owner_principal_type, owner_principal_id = "persona", persona_id
+    else:
+        owner_principal_type, owner_principal_id = "user", "local"
 
     scope_type = (scope_type or "global").strip().lower()
     if scope_type not in ("global", "project"):
@@ -2445,10 +2492,22 @@ def db_add_memory(
                 origin_kind,
                 source_conversation_id,
                 source_message_id,
+                tenant_id,
+                owner_principal_type,
+                owner_principal_id,
+                created_by_principal_type,
+                created_by_principal_id,
+                source_principal_type,
+                source_principal_id,
+                visibility,
+                sharing_mode,
+                provenance_json,
+                persona_principal_id,
+                persona_context_mode,
                 created_at,
                 updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             mem_id,
             content,
@@ -2460,6 +2519,18 @@ def db_add_memory(
             origin_kind,
             source_conversation_id,
             source_message_id,
+            tenant_id,
+            owner_principal_type,
+            owner_principal_id,
+            source_principal_type,
+            source_principal_id,
+            source_principal_type,
+            source_principal_id,
+            policy.memory_visibility,
+            "owner",
+            json.dumps({"source_conversation_id": source_conversation_id, "source_message_id": source_message_id}, ensure_ascii=False, sort_keys=True),
+            persona_id,
+            persona_context_mode,
             now,
             now,
         ))
@@ -2495,6 +2566,18 @@ def db_list_memories(limit: int = 200) -> list[dict]:
                 COALESCE(m.origin_kind, 'user_asserted') AS origin_kind,
                 m.source_conversation_id,
                 m.source_message_id,
+                m.tenant_id,
+                m.owner_principal_type,
+                m.owner_principal_id,
+                m.created_by_principal_type,
+                m.created_by_principal_id,
+                m.source_principal_type,
+                m.source_principal_id,
+                m.visibility,
+                m.sharing_mode,
+                m.provenance_json,
+                m.persona_principal_id,
+                m.persona_context_mode,
                 m.created_at,
                 m.updated_at,
                 (
@@ -2529,6 +2612,8 @@ def db_update_memory(
     origin_kind: str = "user_asserted",
     scope_type: str | None = None,
     scope_id: int | None = None,
+    persona_id: str | None = None,
+    persona_context_mode: str | None = None,
 ) -> dict:
     memory_id = (memory_id or "").strip()
     if not memory_id:
@@ -2541,6 +2626,10 @@ def db_update_memory(
     tags_text = _normalize_tags(tags)
     created_by = (created_by or "user").strip() or "user"
     origin_kind = (origin_kind or "user_asserted").strip() or "user_asserted"
+    persona_id = (persona_id or "").strip() or None
+    persona_context_mode = (persona_context_mode or "").strip().lower() or None
+    if persona_context_mode is not None and persona_context_mode not in ("inherit", "include", "exclude"):
+        persona_context_mode = "inherit"
     now = _utc_now_iso()
 
     with db_session() as conn:
@@ -2567,6 +2656,8 @@ def db_update_memory(
                 scope_id = ?,
                 created_by = ?,
                 origin_kind = ?,
+                persona_principal_id = ?,
+                persona_context_mode = ?,
                 updated_at = ?
             WHERE id = ?
         """, (
@@ -2577,6 +2668,8 @@ def db_update_memory(
             final_scope_id,
             created_by,
             origin_kind,
+            persona_id if persona_id is not None else existing.get("persona_principal_id"),
+            persona_context_mode if persona_context_mode is not None else existing.get("persona_context_mode") or "inherit",
             now,
             memory_id,
         ))
@@ -2638,6 +2731,40 @@ def db_memory_link_conversation(memory_id: str, conversation_id: str) -> None:
             VALUES (?, ?)
         """, (memory_id, conversation_id))
 
+def db_get_memory_access_resource(memory_id: str) -> dict | None:
+    with db_session() as conn:
+        try:
+            mem = _fetch_memory_row(conn, memory_id)
+        except ValueError:
+            return None
+    inherited = []
+    inherited.extend({"resource_type": "project", "resource_id": str(pid)} for pid in mem.get("project_ids") or [])
+    inherited.extend({"resource_type": "conversation", "resource_id": cid} for cid in mem.get("conversation_ids") or [])
+    return {
+        "resource_type": "memory",
+        "resource_id": mem["id"],
+        "tenant_id": mem.get("tenant_id") or "default",
+        "owner_principal_type": mem.get("owner_principal_type"),
+        "owner_principal_id": mem.get("owner_principal_id"),
+        "visibility": mem.get("visibility"),
+        "inherited_from": inherited,
+    }
+
+def db_list_memories_for_persona(persona_id: str, include_unassigned: bool = True, limit: int = 200) -> list[dict]:
+    persona_id = (persona_id or "").strip()
+    if not persona_id:
+        return []
+    memories = db_list_memories(limit=limit)
+    out = []
+    for mem in memories:
+        assigned = (mem.get("persona_principal_id") or "").strip()
+        mode = (mem.get("persona_context_mode") or "inherit").strip().lower()
+        if mode == "exclude":
+            continue
+        if assigned == persona_id or (include_unassigned and not assigned):
+            out.append(mem)
+    return out
+
 def memory_artifact_id(memory_id: str) -> str:
     memory_id = (memory_id or "").strip()
     if not memory_id:
@@ -2685,6 +2812,10 @@ def _memory_artifact_text(mem: dict) -> str:
     if src_msg:
         lines.append(f"Source message: {src_msg}")
 
+    persona_id = (mem.get("persona_principal_id") or "").strip()
+    if persona_id:
+        lines.append(f"Persona: {persona_id}")
+
     lines.append("")
     lines.append((mem.get("content") or "").rstrip())
 
@@ -2703,6 +2834,11 @@ def _memory_artifact_meta(mem: dict) -> dict:
         "source_message_id": mem.get("source_message_id"),
         "project_ids": mem.get("project_ids") or [],
         "conversation_ids": mem.get("conversation_ids") or [],
+        "tenant_id": mem.get("tenant_id") or "default",
+        "owner_principal_type": mem.get("owner_principal_type"),
+        "owner_principal_id": mem.get("owner_principal_id"),
+        "persona_principal_id": mem.get("persona_principal_id"),
+        "persona_context_mode": mem.get("persona_context_mode") or "inherit",
     }
 
 def _upsert_memory_artifact_for_row(conn: sqlite3.Connection, mem: dict) -> str:

--- a/server/db.py
+++ b/server/db.py
@@ -28,7 +28,8 @@ from .db_helpers import (
     _SAFE_ID_RE, DATA_DIR, SCHEMA_VERSION, DB_PATH, 
     _normalize_tags, new_uuid, _sha256_hex, _utc_now_iso, 
     db_session, db_debug_info, _start_schema_init, _end_schema_init, 
-    ensure_parent_dir, _table_exists, _add_column_if_missing, 
+    ensure_parent_dir, _table_exists, _add_column_if_missing,
+    ensure_audit_events_schema,
 )
 # Support legacy migrations from v1-v7. You can remove this after a few releases once most users have migrated or started fresh.
 from .db_migrate import _migrate_schema_legacy
@@ -66,6 +67,9 @@ class FileScope:
 def _migrate_schema_v23(conn) -> None:
     _add_column_if_missing(conn, "files", "meta_json", "TEXT")
 
+def _migrate_schema_v24(conn) -> None:
+    ensure_audit_events_schema(conn)
+
 
 MIGRATIONS: list[tuple[int, Callable]] = [
     (8, _migrate_schema_v8),
@@ -84,6 +88,7 @@ MIGRATIONS: list[tuple[int, Callable]] = [
     (21, _migrate_schema_v21),
     (22, _migrate_schema_v22),
     (23, _migrate_schema_v23),
+    (24, _migrate_schema_v24),
 ]
 
 # endregion

--- a/server/db.py
+++ b/server/db.py
@@ -1073,6 +1073,80 @@ def db_get_message_access_resource(message_id: int) -> dict | None:
             ],
         }
 
+def _conversation_default_access_conn(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str | None = None,
+    project_id: int | None = None,
+    user_id: str | None = None,
+    owner_principal_type: str | None = None,
+    owner_principal_id: str | None = None,
+    created_by_principal_type: str | None = None,
+    created_by_principal_id: str | None = None,
+    visibility: str | None = None,
+    sharing_mode: str | None = None,
+) -> dict:
+    policy = resolve_tenant_policy(tenant_id)
+    access = {
+        "tenant_id": (tenant_id or policy.tenant_id or "default").strip() or "default",
+        "owner_principal_type": "user",
+        "owner_principal_id": "local",
+        "created_by_principal_type": "user",
+        "created_by_principal_id": "local",
+        "visibility": (policy.conversation_visibility or "private").strip() or "private",
+        "sharing_mode": "owner",
+    }
+
+    user_id = (user_id or "local").strip() or "local"
+    profile = conn.execute(
+        """
+        SELECT tenant_id, owner_principal_type, owner_principal_id, visibility, sharing_mode
+        FROM user_profiles
+        WHERE tenant_id = ? AND user_id = ?
+        LIMIT 1
+        """,
+        (access["tenant_id"], user_id),
+    ).fetchone() if _table_exists(conn, "user_profiles") else None
+    if profile:
+        access.update({
+            "tenant_id": profile["tenant_id"] or access["tenant_id"],
+            "owner_principal_type": profile["owner_principal_type"] or access["owner_principal_type"],
+            "owner_principal_id": profile["owner_principal_id"] or access["owner_principal_id"],
+            "visibility": profile["visibility"] or access["visibility"],
+            "sharing_mode": profile["sharing_mode"] or access["sharing_mode"],
+        })
+
+    if project_id is not None:
+        project = conn.execute(
+            """
+            SELECT tenant_id, owner_principal_type, owner_principal_id, visibility, sharing_mode
+            FROM projects
+            WHERE id = ?
+            """,
+            (int(project_id),),
+        ).fetchone()
+        if project:
+            access.update({
+                "tenant_id": project["tenant_id"] or access["tenant_id"],
+                "owner_principal_type": project["owner_principal_type"] or access["owner_principal_type"],
+                "owner_principal_id": project["owner_principal_id"] or access["owner_principal_id"],
+                "visibility": project["visibility"] or access["visibility"],
+                "sharing_mode": "inherit",
+            })
+
+    if owner_principal_type:
+        access["owner_principal_type"] = owner_principal_type.strip() or access["owner_principal_type"]
+    if owner_principal_id:
+        access["owner_principal_id"] = owner_principal_id.strip() or access["owner_principal_id"]
+    access["created_by_principal_type"] = (created_by_principal_type or access["owner_principal_type"]).strip() or access["owner_principal_type"]
+    access["created_by_principal_id"] = (created_by_principal_id or access["owner_principal_id"]).strip() or access["owner_principal_id"]
+    if visibility:
+        access["visibility"] = visibility.strip() or access["visibility"]
+    if sharing_mode:
+        access["sharing_mode"] = sharing_mode.strip() or access["sharing_mode"]
+    return access
+
+
 def db_create_conversation(
     conversation_id: str,
     title: str = "New chat",
@@ -1085,37 +1159,43 @@ def db_create_conversation(
     visibility: str | None = None,
     sharing_mode: str | None = None,
     provenance: dict | None = None,
+    project_id: int | None = None,
+    user_id: str | None = None,
 ) -> None:
     now = _utc_now_iso()
     title = (title or "").strip() or "New chat"
-    policy = resolve_tenant_policy(tenant_id)
-    tenant_id = (tenant_id or policy.tenant_id or "default").strip() or "default"
-    owner_principal_type = (owner_principal_type or "user").strip() or "user"
-    owner_principal_id = (owner_principal_id or "local").strip() or "local"
-    created_by_principal_type = (created_by_principal_type or owner_principal_type).strip() or owner_principal_type
-    created_by_principal_id = (created_by_principal_id or owner_principal_id).strip() or owner_principal_id
-    visibility = (visibility or policy.conversation_visibility or "private").strip() or "private"
-    sharing_mode = (sharing_mode or "owner").strip() or "owner"
     provenance_json = json.dumps(provenance, ensure_ascii=False, sort_keys=True) if provenance else None
 
     with db_session() as conn:
+        access = _conversation_default_access_conn(
+            conn,
+            tenant_id=tenant_id,
+            project_id=project_id,
+            user_id=user_id,
+            owner_principal_type=owner_principal_type,
+            owner_principal_id=owner_principal_id,
+            created_by_principal_type=created_by_principal_type,
+            created_by_principal_id=created_by_principal_id,
+            visibility=visibility,
+            sharing_mode=sharing_mode,
+        )
         conn.execute(
             """
             INSERT INTO conversations(
-                id, title, created_at, updated_at, tenant_id,
+                id, project_id, title, created_at, updated_at, tenant_id,
                 owner_principal_type, owner_principal_id,
                 created_by_principal_type, created_by_principal_id,
                 source_principal_type, source_principal_id,
                 visibility, sharing_mode, provenance_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                conversation_id, title, now, now, tenant_id,
-                owner_principal_type, owner_principal_id,
-                created_by_principal_type, created_by_principal_id,
-                created_by_principal_type, created_by_principal_id,
-                visibility, sharing_mode, provenance_json,
+                conversation_id, project_id, title, now, now, access["tenant_id"],
+                access["owner_principal_type"], access["owner_principal_id"],
+                access["created_by_principal_type"], access["created_by_principal_id"],
+                access["created_by_principal_type"], access["created_by_principal_id"],
+                access["visibility"], access["sharing_mode"], provenance_json,
             ),
         )
 
@@ -1209,9 +1289,26 @@ def db_list_conversations(
 
 def db_set_conversation_project(conversation_id: str, project_id: int | None) -> None:
     with db_session() as conn:
+        if project_id is None:
+            conn.execute(
+                "UPDATE conversations SET project_id = ?, updated_at = ?, sharing_mode = COALESCE(sharing_mode, 'owner') WHERE id = ?",
+                (project_id, _utc_now_iso(), conversation_id),
+            )
+            return
+        access = _conversation_default_access_conn(conn, project_id=int(project_id))
         conn.execute(
-            "UPDATE conversations SET project_id = ?, updated_at = ?, sharing_mode = COALESCE(sharing_mode, 'owner') WHERE id = ?",
-            (project_id, _utc_now_iso(), conversation_id),
+            """
+            UPDATE conversations
+            SET project_id = ?, updated_at = ?, tenant_id = ?,
+                owner_principal_type = ?, owner_principal_id = ?,
+                visibility = ?, sharing_mode = 'inherit'
+            WHERE id = ?
+            """,
+            (
+                int(project_id), _utc_now_iso(), access["tenant_id"],
+                access["owner_principal_type"], access["owner_principal_id"],
+                access["visibility"], conversation_id,
+            ),
         )
 
 def db_set_conversation_archived(conversation_id: str, archived: bool) -> None:

--- a/server/db.py
+++ b/server/db.py
@@ -32,6 +32,7 @@ from .db_helpers import (
     ensure_audit_events_schema, ensure_resource_ownership_columns,
     ensure_access_control_schema, ensure_identity_group_role_schema,
     create_access_control_entry, list_access_control_entries, remove_access_control_entry,
+    log_audit_event,
 )
 # Support legacy migrations from v1-v7. You can remove this after a few releases once most users have migrated or started fresh.
 from .db_migrate import _migrate_schema_legacy
@@ -593,6 +594,89 @@ def db_get_artifact_access_resource(artifact_id: str) -> dict | None:
         elif row["scope_type"] in ("conversation", "chat") and row["scope_uuid"]:
             inherited.append({"resource_type": "conversation", "resource_id": row["scope_uuid"]})
         return _access_resource_from_owned_row("artifact", row, inherited)
+
+
+def db_get_effective_sharing_source(resource_type: str, resource_id: str | int) -> dict | None:
+    resource_type = (resource_type or "").strip().lower()
+    loaders = {
+        "project": lambda rid: db_get_project_access_resource(int(rid)),
+        "file": lambda rid: db_get_file_access_resource(str(rid)),
+        "artifact": lambda rid: db_get_artifact_access_resource(str(rid)),
+        "conversation": lambda rid: db_get_conversation_access_resource(str(rid)),
+        "memory": lambda rid: db_get_memory_access_resource(str(rid)),
+    }
+    loader = loaders.get(resource_type)
+    if loader is None:
+        raise ValueError(f"Unsupported resource_type: {resource_type}")
+    resource = loader(resource_id)
+    if not resource:
+        return None
+    inherited = resource.get("inherited_from") or []
+    return {
+        "resource": resource,
+        "effective_source": inherited[0] if inherited else {"resource_type": resource["resource_type"], "resource_id": resource["resource_id"]},
+        "inherited_from": inherited,
+    }
+
+
+def promote_artifact_access_policy(
+    artifact_id: str,
+    *,
+    owner_user_id: str = "local",
+    visibility: str | None = None,
+    promoted_by_user_id: str = "local",
+) -> bool:
+    artifact_id = (artifact_id or "").strip()
+    if not artifact_id:
+        raise ValueError("artifact_id is required")
+    owner_user_id = (owner_user_id or "local").strip() or "local"
+    promoted_by_user_id = (promoted_by_user_id or "local").strip() or "local"
+    with db_session() as conn:
+        row = conn.execute("SELECT * FROM artifacts WHERE id = ?", (artifact_id,)).fetchone()
+        if not row:
+            return False
+        before = dict(row)
+        try:
+            provenance = json.loads(row["provenance_json"] or "{}")
+            if not isinstance(provenance, dict):
+                provenance = {}
+        except Exception:
+            provenance = {}
+        provenance["promoted_access_policy"] = {
+            "promoted_by_user_id": promoted_by_user_id,
+            "promoted_at": _utc_now_iso(),
+            "previous_sharing_mode": row["sharing_mode"],
+        }
+        conn.execute(
+            """
+            UPDATE artifacts
+            SET owner_user_id = ?, updated_by_user_id = ?,
+                owner_principal_type = 'user', owner_principal_id = ?,
+                visibility = COALESCE(?, visibility), sharing_mode = 'owner',
+                provenance_json = ?, updated_at = ?
+            WHERE id = ?
+            """,
+            (owner_user_id, promoted_by_user_id, owner_user_id, visibility, json.dumps(provenance, ensure_ascii=False, sort_keys=True), _utc_now_iso(), artifact_id),
+        )
+        after = conn.execute("SELECT * FROM artifacts WHERE id = ?", (artifact_id,)).fetchone()
+        log_audit_event(
+            event_type="artifact.access_policy.promote",
+            tenant_id=row["tenant_id"] or "default",
+            actor_principal_type="user",
+            actor_principal_id=promoted_by_user_id,
+            resource_type="artifact",
+            resource_id=artifact_id,
+            target_principal_type="user",
+            target_principal_id=owner_user_id,
+            action="share",
+            summary=f"Promoted artifact {artifact_id} access policy",
+            before=before,
+            after=dict(after) if after else None,
+            conn=conn,
+            raise_on_error=True,
+        )
+        return True
+
 
 def db_get_conversation_project_id(conn, conversation_id: str) -> int | None:
     row = conn.execute(

--- a/server/db.py
+++ b/server/db.py
@@ -29,7 +29,7 @@ from .db_helpers import (
     _normalize_tags, new_uuid, _sha256_hex, _utc_now_iso, 
     db_session, db_debug_info, _start_schema_init, _end_schema_init, 
     ensure_parent_dir, _table_exists, _add_column_if_missing,
-    ensure_audit_events_schema,
+    ensure_audit_events_schema, ensure_resource_ownership_columns,
 )
 # Support legacy migrations from v1-v7. You can remove this after a few releases once most users have migrated or started fresh.
 from .db_migrate import _migrate_schema_legacy
@@ -70,6 +70,9 @@ def _migrate_schema_v23(conn) -> None:
 def _migrate_schema_v24(conn) -> None:
     ensure_audit_events_schema(conn)
 
+def _migrate_schema_v25(conn) -> None:
+    ensure_resource_ownership_columns(conn)
+
 
 MIGRATIONS: list[tuple[int, Callable]] = [
     (8, _migrate_schema_v8),
@@ -89,6 +92,7 @@ MIGRATIONS: list[tuple[int, Callable]] = [
     (22, _migrate_schema_v22),
     (23, _migrate_schema_v23),
     (24, _migrate_schema_v24),
+    (25, _migrate_schema_v25),
 ]
 
 # endregion

--- a/server/db.py
+++ b/server/db.py
@@ -88,6 +88,10 @@ def _migrate_schema_v28(conn) -> None:
     )
 
 
+def _migrate_schema_v29(conn) -> None:
+    ensure_resource_ownership_columns(conn)
+
+
 MIGRATIONS: list[tuple[int, Callable]] = [
     (8, _migrate_schema_v8),
     (9, _migrate_schema_v9),
@@ -110,6 +114,7 @@ MIGRATIONS: list[tuple[int, Callable]] = [
     (26, _migrate_schema_v26),
     (27, _migrate_schema_v27),
     (28, _migrate_schema_v28),
+    (29, _migrate_schema_v29),
 ]
 
 # endregion
@@ -1045,8 +1050,6 @@ def db_get_message_access_resource(message_id: int) -> dict | None:
                 m.id,
                 m.conversation_id,
                 m.tenant_id,
-                m.owner_principal_type,
-                m.owner_principal_id,
                 m.visibility,
                 c.tenant_id AS conversation_tenant_id
             FROM messages m
@@ -1062,9 +1065,9 @@ def db_get_message_access_resource(message_id: int) -> dict | None:
             "resource_type": "message",
             "resource_id": str(row["id"]),
             "tenant_id": tenant_id,
-            "owner_principal_type": row["owner_principal_type"],
-            "owner_principal_id": row["owner_principal_id"],
-            "visibility": row["visibility"],
+            "owner_principal_type": None,
+            "owner_principal_id": None,
+            "visibility": row["visibility"] or "inherit",
             "inherited_from": [
                 {"resource_type": "conversation", "resource_id": row["conversation_id"]}
             ],
@@ -2301,30 +2304,26 @@ def db_add_message(
     with db_session() as conn:
         conv = conn.execute(
             """
-            SELECT tenant_id, owner_principal_type, owner_principal_id, visibility
+            SELECT tenant_id, visibility
             FROM conversations
             WHERE id = ?
             """,
             (conversation_id,),
         ).fetchone()
         tenant_id = (conv["tenant_id"] if conv else None) or "default"
-        owner_principal_type = (conv["owner_principal_type"] if conv else None) or source_principal_type
-        owner_principal_id = (conv["owner_principal_id"] if conv else None) or source_principal_id
         cur = conn.execute(
             """
             INSERT INTO messages(
                 conversation_id, role, content, created_at, meta, author_meta,
-                tenant_id, owner_principal_type, owner_principal_id,
-                created_by_principal_type, created_by_principal_id,
+                tenant_id, created_by_principal_type, created_by_principal_id,
                 source_principal_type, source_principal_id,
                 visibility, sharing_mode, provenance_json
             )
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 conversation_id, role, content, now, meta_json, author_meta_json,
-                tenant_id, owner_principal_type, owner_principal_id,
-                source_principal_type, source_principal_id,
+                tenant_id, source_principal_type, source_principal_id,
                 source_principal_type, source_principal_id,
                 "inherit", "inherit",
                 json.dumps({"conversation_id": conversation_id}, ensure_ascii=False, sort_keys=True),
@@ -2367,7 +2366,7 @@ def db_get_messages_raw(conversation_id: str, limit: int = 200) -> list[dict]:
             """
             SELECT
                 id, role, content, created_at, meta, author_meta,
-                tenant_id, owner_principal_type, owner_principal_id,
+                tenant_id,
                 created_by_principal_type, created_by_principal_id,
                 source_principal_type, source_principal_id,
                 visibility, sharing_mode, provenance_json
@@ -2405,8 +2404,8 @@ def db_get_messages_raw(conversation_id: str, limit: int = 200) -> list[dict]:
                 "meta": meta_obj,
                 "author_meta": author_meta_obj,
                 "tenant_id": r["tenant_id"] or "default",
-                "owner_principal_type": r["owner_principal_type"],
-                "owner_principal_id": r["owner_principal_id"],
+                "owner_principal_type": None,
+                "owner_principal_id": None,
                 "created_by_principal_type": r["created_by_principal_type"],
                 "created_by_principal_id": r["created_by_principal_id"],
                 "source_principal_type": r["source_principal_type"],

--- a/server/db.py
+++ b/server/db.py
@@ -596,6 +596,34 @@ def db_get_artifact_access_resource(artifact_id: str) -> dict | None:
         return _access_resource_from_owned_row("artifact", row, inherited)
 
 
+def db_get_user_profile_access_resource(profile_id: str = "local") -> dict | None:
+    profile_id = (profile_id or "local").strip() or "local"
+    with db_session() as conn:
+        if not _table_exists(conn, "user_profiles"):
+            return None
+        row = conn.execute(
+            """
+            SELECT id, tenant_id, owner_principal_type, owner_principal_id, visibility
+            FROM user_profiles
+            WHERE id = ? OR user_id = ?
+            ORDER BY CASE WHEN id = ? THEN 0 ELSE 1 END
+            LIMIT 1
+            """,
+            (profile_id, profile_id, profile_id),
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "resource_type": "user_profile",
+            "resource_id": row["id"],
+            "tenant_id": row["tenant_id"] or "default",
+            "owner_principal_type": row["owner_principal_type"],
+            "owner_principal_id": row["owner_principal_id"],
+            "visibility": row["visibility"],
+            "inherited_from": [],
+        }
+
+
 def db_get_effective_sharing_source(resource_type: str, resource_id: str | int) -> dict | None:
     resource_type = (resource_type or "").strip().lower()
     loaders = {
@@ -604,6 +632,7 @@ def db_get_effective_sharing_source(resource_type: str, resource_id: str | int) 
         "artifact": lambda rid: db_get_artifact_access_resource(str(rid)),
         "conversation": lambda rid: db_get_conversation_access_resource(str(rid)),
         "memory": lambda rid: db_get_memory_access_resource(str(rid)),
+        "user_profile": lambda rid: db_get_user_profile_access_resource(str(rid)),
     }
     loader = loaders.get(resource_type)
     if loader is None:

--- a/server/db.py
+++ b/server/db.py
@@ -438,13 +438,136 @@ def get_global_project_id() -> int:
         now = _utc_now_iso()
         cur = conn.execute(
             """
-            INSERT INTO projects (name, description, is_global, is_hidden, created_at, updated_at)
-            VALUES (?, ?, 1, 1, ?, ?)
+            INSERT INTO projects (
+                name, description, is_global, is_hidden, created_at, updated_at,
+                tenant_id, owner_principal_type, owner_principal_id,
+                created_by_principal_type, created_by_principal_id,
+                source_principal_type, source_principal_id, visibility, sharing_mode
+            )
+            VALUES (?, ?, 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            ("Global", "Global shared resources", now, now),
+            ("Global", "Global shared resources", now, now, "default", "user", "local", "user", "local", "user", "local", "private", "owner"),
         )
         newid: int = cur.lastrowid # type: ignore[union-attr]
         return newid
+
+def _default_resource_owner(tenant_id: str | None = None) -> dict:
+    policy = resolve_tenant_policy(tenant_id)
+    return {
+        "tenant_id": (tenant_id or policy.tenant_id or "default").strip() or "default",
+        "owner_principal_type": "user",
+        "owner_principal_id": "local",
+        "created_by_principal_type": "user",
+        "created_by_principal_id": "local",
+        "source_principal_type": "user",
+        "source_principal_id": "local",
+        "visibility": "private",
+        "sharing_mode": "owner",
+    }
+
+def _scope_access_defaults_conn(
+    conn: sqlite3.Connection,
+    *,
+    scope_type: str | None = None,
+    scope_id: int | str | None = None,
+    scope_uuid: str | None = None,
+    tenant_id: str | None = None,
+) -> dict:
+    scope_type = (scope_type or "").strip().lower()
+    defaults = _default_resource_owner(tenant_id)
+
+    if scope_type == "project" and scope_id is not None:
+        row = conn.execute(
+            """
+            SELECT tenant_id, owner_principal_type, owner_principal_id, visibility
+            FROM projects
+            WHERE id = ?
+            """,
+            (int(scope_id),),
+        ).fetchone()
+        if row:
+            defaults.update({
+                "tenant_id": row["tenant_id"] or defaults["tenant_id"],
+                "owner_principal_type": row["owner_principal_type"] or defaults["owner_principal_type"],
+                "owner_principal_id": row["owner_principal_id"] or defaults["owner_principal_id"],
+                "visibility": row["visibility"] or defaults["visibility"],
+                "sharing_mode": "inherit",
+            })
+    elif scope_type in ("conversation", "chat") and scope_uuid:
+        row = conn.execute(
+            """
+            SELECT tenant_id, owner_principal_type, owner_principal_id, visibility
+            FROM conversations
+            WHERE id = ?
+            """,
+            (scope_uuid,),
+        ).fetchone()
+        if row:
+            defaults.update({
+                "tenant_id": row["tenant_id"] or defaults["tenant_id"],
+                "owner_principal_type": row["owner_principal_type"] or defaults["owner_principal_type"],
+                "owner_principal_id": row["owner_principal_id"] or defaults["owner_principal_id"],
+                "visibility": row["visibility"] or defaults["visibility"],
+                "sharing_mode": "inherit",
+            })
+    return defaults
+
+def _access_resource_from_owned_row(resource_type: str, row: sqlite3.Row | dict, inherited_from: list[dict] | None = None) -> dict:
+    return {
+        "resource_type": resource_type,
+        "resource_id": str(row["id"]),
+        "tenant_id": row["tenant_id"] or "default",
+        "owner_principal_type": row["owner_principal_type"],
+        "owner_principal_id": row["owner_principal_id"],
+        "visibility": row["visibility"],
+        "inherited_from": inherited_from or [],
+    }
+
+def db_get_project_access_resource(project_id: int) -> dict | None:
+    with db_session() as conn:
+        row = conn.execute(
+            "SELECT id, tenant_id, owner_principal_type, owner_principal_id, visibility FROM projects WHERE id = ?",
+            (int(project_id),),
+        ).fetchone()
+        return _access_resource_from_owned_row("project", row) if row else None
+
+def db_get_file_access_resource(file_id: str) -> dict | None:
+    file_id = (file_id or "").strip()
+    if not file_id:
+        return None
+    with db_session() as conn:
+        row = conn.execute(
+            "SELECT * FROM files WHERE id = ? AND (is_deleted IS NULL OR is_deleted = 0)",
+            (file_id,),
+        ).fetchone()
+        if not row:
+            return None
+        inherited = []
+        if row["scope_type"] == "project" and row["scope_id"] is not None:
+            inherited.append({"resource_type": "project", "resource_id": str(row["scope_id"])})
+        if row["scope_type"] in ("conversation", "chat") and row["scope_uuid"]:
+            inherited.append({"resource_type": "conversation", "resource_id": row["scope_uuid"]})
+        return _access_resource_from_owned_row("file", row, inherited)
+
+def db_get_artifact_access_resource(artifact_id: str) -> dict | None:
+    artifact_id = (artifact_id or "").strip()
+    if not artifact_id:
+        return None
+    with db_session() as conn:
+        row = conn.execute(
+            "SELECT * FROM artifacts WHERE id = ? AND (is_deleted IS NULL OR is_deleted = 0)",
+            (artifact_id,),
+        ).fetchone()
+        if not row:
+            return None
+        inherited = []
+        if (row["source_kind"] or "").startswith("file") and row["source_id"]:
+            inherited.append({"resource_type": "file", "resource_id": row["source_id"]})
+        elif row["scope_type"] == "project" and row["scope_id"] is not None:
+            inherited.append({"resource_type": "project", "resource_id": str(row["scope_id"])})
+        elif row["scope_type"] in ("conversation", "chat") and row["scope_uuid"]:
+            inherited.append({"resource_type": "conversation", "resource_id": row["scope_uuid"]})
+        return _access_resource_from_owned_row("artifact", row, inherited)
 
 def db_get_conversation_project_id(conn, conversation_id: str) -> int | None:
     row = conn.execute(
@@ -465,7 +588,7 @@ def db_get_or_create_project(name: str, visibility: str = "private") -> dict:
 
     with db_session() as conn:
         row = conn.execute(
-            "SELECT id, name, visibility, created_at, updated_at FROM projects WHERE name = ?",
+            "SELECT * FROM projects WHERE name = ?",
             (name,),
         ).fetchone()
         if row:
@@ -475,19 +598,28 @@ def db_get_or_create_project(name: str, visibility: str = "private") -> dict:
                 "visibility": row["visibility"],
                 "created_at": row["created_at"],
                 "updated_at": row["updated_at"],
+                "tenant_id": row["tenant_id"] or "default",
+                "owner_principal_type": row["owner_principal_type"],
+                "owner_principal_id": row["owner_principal_id"],
+                "sharing_mode": row["sharing_mode"],
             }
 
         puuid = str(uuid.uuid4())
         now = _utc_now_iso()
         conn.execute(
             """
-            INSERT INTO projects (uuid, name, visibility, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO projects (
+                uuid, name, visibility, created_at, updated_at, tenant_id,
+                owner_principal_type, owner_principal_id,
+                created_by_principal_type, created_by_principal_id,
+                source_principal_type, source_principal_id, sharing_mode
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (puuid, name, visibility, now, now),
+            (puuid, name, visibility, now, now, "default", "user", "local", "user", "local", "user", "local", "owner"),
         )
         row2 = conn.execute(
-            "SELECT id, name, visibility, created_at, updated_at FROM projects WHERE name = ?",
+            "SELECT * FROM projects WHERE name = ?",
             (name,),
         ).fetchone()
         return {
@@ -496,6 +628,10 @@ def db_get_or_create_project(name: str, visibility: str = "private") -> dict:
             "visibility": row2["visibility"],
             "created_at": row2["created_at"],
             "updated_at": row2["updated_at"],
+            "tenant_id": row2["tenant_id"] or "default",
+            "owner_principal_type": row2["owner_principal_type"],
+            "owner_principal_id": row2["owner_principal_id"],
+            "sharing_mode": row2["sharing_mode"],
         }
 
 def db_project_add_conversation(project_id: int, conversation_id: str, set_primary: bool = True) -> None:
@@ -6780,10 +6916,15 @@ def db_register_file(name: str, path: str, mime_type: str | None = None) -> dict
     with db_session() as conn:
         conn.execute(
             """
-            INSERT INTO files (id, name, path, mime_type, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO files (
+                id, name, path, mime_type, created_at, updated_at, tenant_id,
+                owner_principal_type, owner_principal_id,
+                created_by_principal_type, created_by_principal_id,
+                source_principal_type, source_principal_id, visibility, sharing_mode
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (fid, name, path, mime_type, now, now),
+            (fid, name, path, mime_type, now, now, "default", "user", "local", "user", "local", "user", "local", "private", "owner"),
         )
     return {"id": fid}
 
@@ -6801,6 +6942,22 @@ def db_project_add_file(project_id: int, file_id: str) -> None:
         conn.execute(
             "INSERT OR IGNORE INTO project_files (project_id, file_id) VALUES (?, ?)",
             (int(project_id), file_id),
+        )
+        access = _scope_access_defaults_conn(conn, scope_type="project", scope_id=int(project_id))
+        conn.execute(
+            """
+            UPDATE files
+            SET scope_type = COALESCE(scope_type, 'project'),
+                scope_id = COALESCE(scope_id, ?),
+                tenant_id = ?,
+                owner_principal_type = COALESCE(owner_principal_type, ?),
+                owner_principal_id = COALESCE(owner_principal_id, ?),
+                visibility = COALESCE(visibility, ?),
+                sharing_mode = 'inherit',
+                updated_at = ?
+            WHERE id = ?
+            """,
+            (int(project_id), access["tenant_id"], access["owner_principal_type"], access["owner_principal_id"], access["visibility"], _utc_now_iso(), file_id),
         )
 
 def db_conversation_link_file(conversation_id: str, file_id: str) -> None:
@@ -6824,6 +6981,22 @@ def db_conversation_link_file(conversation_id: str, file_id: str) -> None:
             VALUES (?, ?)
             """,
             (conversation_id, file_id),
+        )
+        access = _scope_access_defaults_conn(conn, scope_type="conversation", scope_uuid=conversation_id)
+        conn.execute(
+            """
+            UPDATE files
+            SET scope_type = COALESCE(scope_type, 'conversation'),
+                scope_uuid = COALESCE(scope_uuid, ?),
+                tenant_id = ?,
+                owner_principal_type = COALESCE(owner_principal_type, ?),
+                owner_principal_id = COALESCE(owner_principal_id, ?),
+                visibility = COALESCE(visibility, ?),
+                sharing_mode = 'inherit',
+                updated_at = ?
+            WHERE id = ?
+            """,
+            (conversation_id, access["tenant_id"], access["owner_principal_type"], access["owner_principal_id"], access["visibility"], _utc_now_iso(), file_id),
         )
 
 def db_list_files_for_conversation(
@@ -6993,6 +7166,7 @@ def db_register_scoped_file(
     now = _utc_now_iso()
 
     with db_session() as conn:
+        access = _scope_access_defaults_conn(conn, scope_type=scope_type, scope_id=scope_id, scope_uuid=scope_uuid)
         conn.execute(
             """
             INSERT INTO files (
@@ -7009,10 +7183,20 @@ def db_register_scoped_file(
                 provenance,
                 description,
                 is_deleted,
+                tenant_id,
+                owner_principal_type,
+                owner_principal_id,
+                created_by_principal_type,
+                created_by_principal_id,
+                source_principal_type,
+                source_principal_id,
+                visibility,
+                sharing_mode,
+                provenance_json,
                 created_at,
                 updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 fid,
@@ -7027,6 +7211,16 @@ def db_register_scoped_file(
                 url,
                 provenance,
                 description,
+                access["tenant_id"],
+                access["owner_principal_type"],
+                access["owner_principal_id"],
+                access["created_by_principal_type"],
+                access["created_by_principal_id"],
+                access["source_principal_type"],
+                access["source_principal_id"],
+                access["visibility"],
+                access["sharing_mode"],
+                json.dumps({"provenance": provenance, "url": url}, ensure_ascii=False, sort_keys=True),
                 now,
                 now,
             ),
@@ -8840,12 +9034,42 @@ def upsert_artifact_text(
         source_kind=source_kind,
         source_id=source_id,
     )
+    access = None
+    if (source_kind or "").startswith("file") and source_id:
+        file_row = conn.execute(
+            "SELECT tenant_id, owner_principal_type, owner_principal_id, visibility FROM files WHERE id = ?",
+            (source_id,),
+        ).fetchone()
+        if file_row:
+            access = {
+                "tenant_id": file_row["tenant_id"] or "default",
+                "owner_principal_type": file_row["owner_principal_type"] or "user",
+                "owner_principal_id": file_row["owner_principal_id"] or "local",
+                "visibility": file_row["visibility"] or "private",
+                "sharing_mode": "inherit",
+            }
+    if access is None:
+        access = _scope_access_defaults_conn(conn, scope_type=scope_type, scope_id=scope_id)
     conn.execute(
         """
-        INSERT OR REPLACE INTO artifacts (id, source_kind, source_id, title, scope_type, scope_id, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        INSERT OR REPLACE INTO artifacts (
+            id, source_kind, source_id, title, scope_type, scope_id, updated_at,
+            tenant_id, owner_principal_type, owner_principal_id,
+            created_by_principal_type, created_by_principal_id,
+            source_principal_type, source_principal_id, visibility, sharing_mode, provenance_json
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
-        (artifact_id, source_kind, source_id, title, scope_type, scope_id, _utc_now_iso()),
+        (
+            artifact_id, source_kind, source_id, title, scope_type, scope_id, _utc_now_iso(),
+            access["tenant_id"], access["owner_principal_type"], access["owner_principal_id"],
+            access.get("source_principal_type", access["owner_principal_type"]),
+            access.get("source_principal_id", access["owner_principal_id"]),
+            access.get("source_principal_type", access["owner_principal_type"]),
+            access.get("source_principal_id", access["owner_principal_id"]),
+            access["visibility"], access["sharing_mode"],
+            json.dumps({"source_kind": source_kind, "source_id": source_id}, ensure_ascii=False, sort_keys=True),
+        ),
     )
     # Hopefully that worked and now we have...
     row = conn.execute(

--- a/server/db_helpers.py
+++ b/server/db_helpers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, Iterator
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-SCHEMA_VERSION = 27
+SCHEMA_VERSION = 28
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT / "data"

--- a/server/db_helpers.py
+++ b/server/db_helpers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, Iterator
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-SCHEMA_VERSION = 23
+SCHEMA_VERSION = 24
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT / "data"
@@ -25,6 +25,129 @@ def _utc_now_iso() -> str:
 
 def _sha256_hex(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8", errors="strict")).hexdigest()
+
+def _audit_metadata_json(metadata: Any | None) -> str | None:
+    if metadata is None:
+        return None
+    if isinstance(metadata, str):
+        value = metadata.strip()
+        return value or None
+    return json.dumps(metadata, ensure_ascii=False, sort_keys=True)
+
+def ensure_audit_events_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS audit_events (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            event_type TEXT NOT NULL,
+            actor_principal_type TEXT,
+            actor_principal_id TEXT,
+            resource_type TEXT,
+            resource_id TEXT,
+            action TEXT,
+            decision TEXT,
+            reason TEXT,
+            request_id TEXT,
+            source_ip TEXT,
+            user_agent TEXT,
+            metadata_json TEXT,
+            created_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_audit_events_tenant_created
+            ON audit_events(tenant_id, created_at);
+        CREATE INDEX IF NOT EXISTS idx_audit_events_resource
+            ON audit_events(resource_type, resource_id, created_at);
+        CREATE INDEX IF NOT EXISTS idx_audit_events_actor
+            ON audit_events(actor_principal_type, actor_principal_id, created_at);
+        CREATE INDEX IF NOT EXISTS idx_audit_events_event_type
+            ON audit_events(event_type, created_at);
+        CREATE INDEX IF NOT EXISTS idx_audit_events_request_id
+            ON audit_events(request_id);
+        """
+    )
+
+def log_audit_event(
+    *,
+    event_type: str,
+    tenant_id: str = "default",
+    actor_principal_type: str | None = None,
+    actor_principal_id: str | None = None,
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+    action: str | None = None,
+    decision: str | None = None,
+    reason: str | None = None,
+    request_id: str | None = None,
+    source_ip: str | None = None,
+    user_agent: str | None = None,
+    metadata: Any | None = None,
+    conn: sqlite3.Connection | None = None,
+    raise_on_error: bool = False,
+) -> str | None:
+    event_type = (event_type or "").strip()
+    if not event_type:
+        raise ValueError("event_type is required")
+
+    audit_id = new_uuid()
+    values = (
+        audit_id,
+        (tenant_id or "default").strip() or "default",
+        event_type,
+        (actor_principal_type or "").strip() or None,
+        (actor_principal_id or "").strip() or None,
+        (resource_type or "").strip() or None,
+        (resource_id or "").strip() or None,
+        (action or "").strip() or None,
+        (decision or "").strip() or None,
+        (reason or "").strip() or None,
+        (request_id or "").strip() or None,
+        (source_ip or "").strip() or None,
+        (user_agent or "").strip() or None,
+        _audit_metadata_json(metadata),
+        _utc_now_iso(),
+    )
+
+    def _insert(target: sqlite3.Connection) -> None:
+        target.execute(
+            """
+            INSERT INTO audit_events (
+                id, tenant_id, event_type, actor_principal_type, actor_principal_id,
+                resource_type, resource_id, action, decision, reason, request_id,
+                source_ip, user_agent, metadata_json, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            values,
+        )
+
+    try:
+        if conn is not None:
+            _insert(conn)
+        else:
+            with db_session() as sconn:
+                _insert(sconn)
+    except sqlite3.Error:
+        if raise_on_error:
+            raise
+        return None
+
+    return audit_id
+
+def get_audit_event(audit_id: str, conn: sqlite3.Connection | None = None) -> dict | None:
+    audit_id = (audit_id or "").strip()
+    if not audit_id:
+        return None
+
+    def _fetch(target: sqlite3.Connection) -> dict | None:
+        row = target.execute("SELECT * FROM audit_events WHERE id = ?", (audit_id,)).fetchone()
+        return dict(row) if row else None
+
+    if conn is not None:
+        return _fetch(conn)
+    with db_session() as sconn:
+        return _fetch(sconn)
 
 def ensure_parent_dir(p: Path) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)

--- a/server/db_helpers.py
+++ b/server/db_helpers.py
@@ -699,6 +699,31 @@ def list_access_control_entries(
     with db_session() as sconn:
         return _fetch(sconn)
 
+BUILT_IN_ROLE_NAMES = {
+    "global_admin",
+    "tenant_admin",
+    "tenant_member",
+    "tenant_viewer",
+    "persona_manager",
+    "data_steward",
+    "auditor",
+}
+
+_BUILT_IN_ROLE_PERMISSIONS = {
+    "global_admin": ("manage", "share", "view", "edit", "archive", "soft_remove", "permanent_remove", "restore", "use_in_context", "audit"),
+    "tenant_admin": ("manage", "share", "view", "edit", "archive", "soft_remove", "restore", "use_in_context", "audit"),
+    "tenant_member": ("view", "edit", "use_in_context"),
+    "tenant_viewer": ("view",),
+    "persona_manager": ("view", "edit", "use_in_context", "manage"),
+    "data_steward": ("view", "edit", "archive", "restore", "audit"),
+    "auditor": ("view", "audit"),
+}
+
+
+def is_builtin_identity_role(name: str) -> bool:
+    return (name or "").strip().lower() in BUILT_IN_ROLE_NAMES
+
+
 def ensure_identity_group_role_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(
         """
@@ -745,6 +770,21 @@ def ensure_identity_group_role_schema(conn: sqlite3.Connection) -> None:
             UNIQUE(tenant_id, name)
         );
 
+        CREATE TABLE IF NOT EXISTS identity_role_permissions (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            role_id TEXT NOT NULL,
+            permission TEXT NOT NULL,
+            effect TEXT NOT NULL DEFAULT 'allow' CHECK(effect IN ('allow', 'deny')),
+            resource_type TEXT,
+            created_by_principal_type TEXT,
+            created_by_principal_id TEXT,
+            created_at TEXT NOT NULL,
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY(role_id) REFERENCES identity_roles(id) ON DELETE CASCADE,
+            UNIQUE(tenant_id, role_id, permission, effect, resource_type, is_deleted)
+        );
+
         CREATE TABLE IF NOT EXISTS identity_role_assignments (
             id TEXT PRIMARY KEY,
             tenant_id TEXT NOT NULL DEFAULT 'default',
@@ -768,12 +808,397 @@ def ensure_identity_group_role_schema(conn: sqlite3.Connection) -> None:
             ON identity_group_members(tenant_id, member_principal_type, member_principal_id, is_deleted);
         CREATE INDEX IF NOT EXISTS idx_identity_roles_tenant
             ON identity_roles(tenant_id, is_deleted);
+        CREATE INDEX IF NOT EXISTS idx_identity_role_permissions_role
+            ON identity_role_permissions(tenant_id, role_id, is_deleted);
+        CREATE INDEX IF NOT EXISTS idx_identity_role_permissions_permission
+            ON identity_role_permissions(tenant_id, permission, effect, is_deleted);
         CREATE INDEX IF NOT EXISTS idx_identity_role_assignments_role
             ON identity_role_assignments(tenant_id, role_id, is_deleted);
         CREATE INDEX IF NOT EXISTS idx_identity_role_assignments_principal
             ON identity_role_assignments(tenant_id, principal_type, principal_id, is_deleted);
         """
     )
+    seed_builtin_identity_roles(conn)
+
+
+def _identity_now() -> str:
+    return _utc_now_iso()
+
+
+def _identity_audit(
+    conn: sqlite3.Connection,
+    *,
+    event_type: str,
+    tenant_id: str,
+    actor_principal_type: str | None,
+    actor_principal_id: str | None,
+    resource_type: str,
+    resource_id: str,
+    summary: str,
+    before: dict | None = None,
+    after: dict | None = None,
+) -> None:
+    ensure_audit_events_schema(conn)
+    log_audit_event(
+        event_type=event_type,
+        tenant_id=tenant_id,
+        actor_principal_type=actor_principal_type or "user",
+        actor_principal_id=actor_principal_id or "local",
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action="manage_identity",
+        summary=summary,
+        before=before,
+        after=after,
+        conn=conn,
+        raise_on_error=True,
+    )
+
+
+def seed_builtin_identity_roles(conn: sqlite3.Connection, tenant_id: str = "default") -> None:
+    now = _identity_now()
+    for name, permissions in _BUILT_IN_ROLE_PERMISSIONS.items():
+        role_tenant = "global" if name == "global_admin" else (tenant_id or "default")
+        role_id = f"builtin:{role_tenant}:{name}"
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO identity_roles (
+                id, tenant_id, name, display_name, description,
+                created_by_principal_type, created_by_principal_id, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, 'service', 'system', ?, ?)
+            """,
+            (role_id, role_tenant, name, name.replace("_", " ").title(), "Built-in role", now, now),
+        )
+        for permission in permissions:
+            perm_id = f"builtin:{role_tenant}:{name}:{permission}"
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO identity_role_permissions (
+                    id, tenant_id, role_id, permission, effect, resource_type,
+                    created_by_principal_type, created_by_principal_id, created_at
+                )
+                VALUES (?, ?, ?, ?, 'allow', NULL, 'service', 'system', ?)
+                """,
+                (perm_id, role_tenant, role_id, permission, now),
+            )
+
+
+def create_identity_group(
+    *,
+    name: str,
+    tenant_id: str = "default",
+    display_name: str | None = None,
+    description: str | None = None,
+    created_by_principal_type: str | None = None,
+    created_by_principal_id: str | None = None,
+    conn: sqlite3.Connection | None = None,
+) -> str:
+    def _create(target: sqlite3.Connection) -> str:
+        ensure_identity_group_role_schema(target)
+        group_id = new_uuid()
+        now = _identity_now()
+        values = (
+            group_id, tenant_id or "default", _required_acl_value("name", name).lower(),
+            (display_name or name).strip(), (description or "").strip() or None,
+            (created_by_principal_type or "user").strip() or "user",
+            (created_by_principal_id or "local").strip() or "local", now, now,
+        )
+        target.execute(
+            """
+            INSERT INTO identity_groups (
+                id, tenant_id, name, display_name, description,
+                created_by_principal_type, created_by_principal_id, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            values,
+        )
+        row = target.execute("SELECT * FROM identity_groups WHERE id = ?", (group_id,)).fetchone()
+        _identity_audit(target, event_type="identity_group.create", tenant_id=values[1], actor_principal_type=values[5], actor_principal_id=values[6], resource_type="identity_group", resource_id=group_id, summary=f"Created group {values[2]}", after=dict(row) if row else None)
+        return group_id
+    if conn is not None:
+        return _create(conn)
+    with db_session() as active_conn:
+        return _create(active_conn)
+
+
+def list_identity_groups(*, tenant_id: str | None = None, include_deleted: bool = False, conn: sqlite3.Connection | None = None) -> list[dict]:
+    def _list(target: sqlite3.Connection) -> list[dict]:
+        ensure_identity_group_role_schema(target)
+        where = [] if include_deleted else ["is_deleted = 0"]
+        params: list[Any] = []
+        if tenant_id:
+            where.append("tenant_id = ?")
+            params.append(tenant_id)
+        sql = "SELECT * FROM identity_groups" + (" WHERE " + " AND ".join(where) if where else "") + " ORDER BY tenant_id, name"
+        return [dict(r) for r in target.execute(sql, params).fetchall()]
+    if conn is not None:
+        return _list(conn)
+    with db_session() as active_conn:
+        return _list(active_conn)
+
+
+def update_identity_group(group_id: str, *, display_name: str | None = None, description: str | None = None, is_deleted: bool | None = None, actor_principal_type: str | None = None, actor_principal_id: str | None = None, conn: sqlite3.Connection | None = None) -> bool:
+    def _update(target: sqlite3.Connection) -> bool:
+        before_row = target.execute("SELECT * FROM identity_groups WHERE id = ?", (group_id,)).fetchone()
+        if not before_row:
+            return False
+        before = dict(before_row)
+        target.execute(
+            """
+            UPDATE identity_groups
+            SET display_name = COALESCE(?, display_name), description = COALESCE(?, description),
+                is_deleted = COALESCE(?, is_deleted), updated_at = ?
+            WHERE id = ?
+            """,
+            (display_name, description, None if is_deleted is None else int(is_deleted), _identity_now(), group_id),
+        )
+        after = dict(target.execute("SELECT * FROM identity_groups WHERE id = ?", (group_id,)).fetchone())
+        _identity_audit(target, event_type="identity_group.update", tenant_id=after["tenant_id"], actor_principal_type=actor_principal_type, actor_principal_id=actor_principal_id, resource_type="identity_group", resource_id=group_id, summary=f"Updated group {after['name']}", before=before, after=after)
+        return True
+    if conn is not None:
+        return _update(conn)
+    with db_session() as active_conn:
+        return _update(active_conn)
+
+
+def add_identity_group_member(*, group_id: str, member_principal_type: str, member_principal_id: str, tenant_id: str = "default", added_by_principal_type: str | None = None, added_by_principal_id: str | None = None, expires_at: str | None = None, conn: sqlite3.Connection | None = None) -> str:
+    def _add(target: sqlite3.Connection) -> str:
+        ensure_identity_group_role_schema(target)
+        member_type = _validate_ace_principal_type(member_principal_type)
+        member_id = _required_acl_value("member_principal_id", member_principal_id)
+        membership_id = new_uuid()
+        now = _identity_now()
+        target.execute(
+            """
+            INSERT INTO identity_group_members (
+                id, tenant_id, group_id, member_principal_type, member_principal_id,
+                added_by_principal_type, added_by_principal_id, created_at, expires_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (membership_id, tenant_id or "default", group_id, member_type, member_id, added_by_principal_type or "user", added_by_principal_id or "local", now, expires_at),
+        )
+        row = target.execute("SELECT * FROM identity_group_members WHERE id = ?", (membership_id,)).fetchone()
+        _identity_audit(target, event_type="identity_group_member.add", tenant_id=tenant_id or "default", actor_principal_type=added_by_principal_type, actor_principal_id=added_by_principal_id, resource_type="identity_group", resource_id=group_id, summary=f"Added {member_type}:{member_id} to group", after=dict(row) if row else None)
+        return membership_id
+    if conn is not None:
+        return _add(conn)
+    with db_session() as active_conn:
+        return _add(active_conn)
+
+
+def list_identity_group_members(*, group_id: str | None = None, tenant_id: str | None = None, member_principal_type: str | None = None, member_principal_id: str | None = None, include_deleted: bool = False, conn: sqlite3.Connection | None = None) -> list[dict]:
+    def _list(target: sqlite3.Connection) -> list[dict]:
+        ensure_identity_group_role_schema(target)
+        where = [] if include_deleted else ["is_deleted = 0"]
+        params: list[Any] = []
+        for col, value in (("tenant_id", tenant_id), ("group_id", group_id), ("member_principal_type", member_principal_type), ("member_principal_id", member_principal_id)):
+            if value:
+                where.append(f"{col} = ?")
+                params.append(value)
+        sql = "SELECT * FROM identity_group_members" + (" WHERE " + " AND ".join(where) if where else "") + " ORDER BY created_at, id"
+        return [dict(r) for r in target.execute(sql, params).fetchall()]
+    if conn is not None:
+        return _list(conn)
+    with db_session() as active_conn:
+        return _list(active_conn)
+
+
+def create_identity_role(*, name: str, tenant_id: str = "default", display_name: str | None = None, description: str | None = None, created_by_principal_type: str | None = None, created_by_principal_id: str | None = None, conn: sqlite3.Connection | None = None) -> str:
+    def _create(target: sqlite3.Connection) -> str:
+        ensure_identity_group_role_schema(target)
+        role_id = new_uuid()
+        now = _identity_now()
+        values = (role_id, tenant_id or "default", _required_acl_value("name", name).lower(), (display_name or name).strip(), (description or "").strip() or None, created_by_principal_type or "user", created_by_principal_id or "local", now, now)
+        target.execute("""
+            INSERT INTO identity_roles (id, tenant_id, name, display_name, description, created_by_principal_type, created_by_principal_id, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, values)
+        row = target.execute("SELECT * FROM identity_roles WHERE id = ?", (role_id,)).fetchone()
+        _identity_audit(target, event_type="identity_role.create", tenant_id=values[1], actor_principal_type=values[5], actor_principal_id=values[6], resource_type="identity_role", resource_id=role_id, summary=f"Created role {values[2]}", after=dict(row) if row else None)
+        return role_id
+    if conn is not None:
+        return _create(conn)
+    with db_session() as active_conn:
+        return _create(active_conn)
+
+
+def list_identity_roles(*, tenant_id: str | None = None, include_deleted: bool = False, conn: sqlite3.Connection | None = None) -> list[dict]:
+    def _list(target: sqlite3.Connection) -> list[dict]:
+        ensure_identity_group_role_schema(target)
+        where = [] if include_deleted else ["is_deleted = 0"]
+        params: list[Any] = []
+        if tenant_id:
+            where.append("tenant_id = ?")
+            params.append(tenant_id)
+        sql = "SELECT * FROM identity_roles" + (" WHERE " + " AND ".join(where) if where else "") + " ORDER BY tenant_id, name"
+        return [dict(r) for r in target.execute(sql, params).fetchall()]
+    if conn is not None:
+        return _list(conn)
+    with db_session() as active_conn:
+        return _list(active_conn)
+
+
+def update_identity_role(role_id: str, *, display_name: str | None = None, description: str | None = None, is_deleted: bool | None = None, actor_principal_type: str | None = None, actor_principal_id: str | None = None, conn: sqlite3.Connection | None = None) -> bool:
+    def _update(target: sqlite3.Connection) -> bool:
+        before_row = target.execute("SELECT * FROM identity_roles WHERE id = ?", (role_id,)).fetchone()
+        if not before_row:
+            return False
+        before = dict(before_row)
+        target.execute("""
+            UPDATE identity_roles
+            SET display_name = COALESCE(?, display_name), description = COALESCE(?, description), is_deleted = COALESCE(?, is_deleted), updated_at = ?
+            WHERE id = ?
+        """, (display_name, description, None if is_deleted is None else int(is_deleted), _identity_now(), role_id))
+        after = dict(target.execute("SELECT * FROM identity_roles WHERE id = ?", (role_id,)).fetchone())
+        _identity_audit(target, event_type="identity_role.update", tenant_id=after["tenant_id"], actor_principal_type=actor_principal_type, actor_principal_id=actor_principal_id, resource_type="identity_role", resource_id=role_id, summary=f"Updated role {after['name']}", before=before, after=after)
+        return True
+    if conn is not None:
+        return _update(conn)
+    with db_session() as active_conn:
+        return _update(active_conn)
+
+
+def add_identity_role_permission(*, role_id: str, permission: str, tenant_id: str = "default", effect: str = "allow", resource_type: str | None = None, created_by_principal_type: str | None = None, created_by_principal_id: str | None = None, conn: sqlite3.Connection | None = None) -> str:
+    def _add(target: sqlite3.Connection) -> str:
+        ensure_identity_group_role_schema(target)
+        perm = _validate_ace_action(permission)
+        normalized_effect = _required_acl_value("effect", effect).lower()
+        if normalized_effect not in _VALID_ACE_EFFECTS:
+            raise ValueError("effect must be 'allow' or 'deny'")
+        permission_id = new_uuid()
+        now = _identity_now()
+        target.execute("""
+            INSERT INTO identity_role_permissions (id, tenant_id, role_id, permission, effect, resource_type, created_by_principal_type, created_by_principal_id, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, (permission_id, tenant_id or "default", role_id, perm, normalized_effect, (resource_type or "").strip() or None, created_by_principal_type or "user", created_by_principal_id or "local", now))
+        row = target.execute("SELECT * FROM identity_role_permissions WHERE id = ?", (permission_id,)).fetchone()
+        _identity_audit(target, event_type="identity_role_permission.add", tenant_id=tenant_id or "default", actor_principal_type=created_by_principal_type, actor_principal_id=created_by_principal_id, resource_type="identity_role", resource_id=role_id, summary=f"Added {normalized_effect} {perm} role permission", after=dict(row) if row else None)
+        return permission_id
+    if conn is not None:
+        return _add(conn)
+    with db_session() as active_conn:
+        return _add(active_conn)
+
+
+def list_identity_role_permissions(*, role_id: str | None = None, tenant_id: str | None = None, include_deleted: bool = False, conn: sqlite3.Connection | None = None) -> list[dict]:
+    def _list(target: sqlite3.Connection) -> list[dict]:
+        ensure_identity_group_role_schema(target)
+        where = [] if include_deleted else ["is_deleted = 0"]
+        params: list[Any] = []
+        for col, value in (("tenant_id", tenant_id), ("role_id", role_id)):
+            if value:
+                where.append(f"{col} = ?")
+                params.append(value)
+        sql = "SELECT * FROM identity_role_permissions" + (" WHERE " + " AND ".join(where) if where else "") + " ORDER BY created_at, id"
+        return [dict(r) for r in target.execute(sql, params).fetchall()]
+    if conn is not None:
+        return _list(conn)
+    with db_session() as active_conn:
+        return _list(active_conn)
+
+
+def assign_identity_role(*, role_id: str, principal_type: str, principal_id: str, tenant_id: str = "default", granted_by_principal_type: str | None = None, granted_by_principal_id: str | None = None, expires_at: str | None = None, conn: sqlite3.Connection | None = None) -> str:
+    def _assign(target: sqlite3.Connection) -> str:
+        ensure_identity_group_role_schema(target)
+        normalized_type = _validate_ace_principal_type(principal_type)
+        assignment_id = new_uuid()
+        now = _identity_now()
+        target.execute("""
+            INSERT INTO identity_role_assignments (id, tenant_id, role_id, principal_type, principal_id, granted_by_principal_type, granted_by_principal_id, created_at, expires_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, (assignment_id, tenant_id or "default", role_id, normalized_type, _required_acl_value("principal_id", principal_id), granted_by_principal_type or "user", granted_by_principal_id or "local", now, expires_at))
+        row = target.execute("SELECT * FROM identity_role_assignments WHERE id = ?", (assignment_id,)).fetchone()
+        _identity_audit(target, event_type="identity_role_assignment.add", tenant_id=tenant_id or "default", actor_principal_type=granted_by_principal_type, actor_principal_id=granted_by_principal_id, resource_type="identity_role", resource_id=role_id, summary=f"Assigned role to {normalized_type}:{principal_id}", after=dict(row) if row else None)
+        return assignment_id
+    if conn is not None:
+        return _assign(conn)
+    with db_session() as active_conn:
+        return _assign(active_conn)
+
+
+def list_identity_role_assignments(*, role_id: str | None = None, tenant_id: str | None = None, principal_type: str | None = None, principal_id: str | None = None, include_deleted: bool = False, conn: sqlite3.Connection | None = None) -> list[dict]:
+    def _list(target: sqlite3.Connection) -> list[dict]:
+        ensure_identity_group_role_schema(target)
+        where = [] if include_deleted else ["is_deleted = 0"]
+        params: list[Any] = []
+        for col, value in (("tenant_id", tenant_id), ("role_id", role_id), ("principal_type", principal_type), ("principal_id", principal_id)):
+            if value:
+                where.append(f"{col} = ?")
+                params.append(value)
+        sql = "SELECT * FROM identity_role_assignments" + (" WHERE " + " AND ".join(where) if where else "") + " ORDER BY created_at, id"
+        return [dict(r) for r in target.execute(sql, params).fetchall()]
+    if conn is not None:
+        return _list(conn)
+    with db_session() as active_conn:
+        return _list(active_conn)
+
+
+def update_identity_group_member(membership_id: str, *, expires_at: str | None = None, is_deleted: bool | None = None, actor_principal_type: str | None = None, actor_principal_id: str | None = None, conn: sqlite3.Connection | None = None) -> bool:
+    def _update(target: sqlite3.Connection) -> bool:
+        before_row = target.execute("SELECT * FROM identity_group_members WHERE id = ?", (membership_id,)).fetchone()
+        if not before_row:
+            return False
+        before = dict(before_row)
+        target.execute("""
+            UPDATE identity_group_members
+            SET expires_at = COALESCE(?, expires_at), is_deleted = COALESCE(?, is_deleted)
+            WHERE id = ?
+        """, (expires_at, None if is_deleted is None else int(is_deleted), membership_id))
+        after = dict(target.execute("SELECT * FROM identity_group_members WHERE id = ?", (membership_id,)).fetchone())
+        _identity_audit(target, event_type="identity_group_member.update", tenant_id=after["tenant_id"], actor_principal_type=actor_principal_type, actor_principal_id=actor_principal_id, resource_type="identity_group", resource_id=after["group_id"], summary=f"Updated group membership {membership_id}", before=before, after=after)
+        return True
+    if conn is not None:
+        return _update(conn)
+    with db_session() as active_conn:
+        return _update(active_conn)
+
+
+def update_identity_role_permission(permission_id: str, *, effect: str | None = None, resource_type: str | None = None, is_deleted: bool | None = None, actor_principal_type: str | None = None, actor_principal_id: str | None = None, conn: sqlite3.Connection | None = None) -> bool:
+    def _update(target: sqlite3.Connection) -> bool:
+        before_row = target.execute("SELECT * FROM identity_role_permissions WHERE id = ?", (permission_id,)).fetchone()
+        if not before_row:
+            return False
+        before = dict(before_row)
+        normalized_effect = None
+        if effect is not None:
+            normalized_effect = _required_acl_value("effect", effect).lower()
+            if normalized_effect not in _VALID_ACE_EFFECTS:
+                raise ValueError("effect must be 'allow' or 'deny'")
+        target.execute("""
+            UPDATE identity_role_permissions
+            SET effect = COALESCE(?, effect), resource_type = COALESCE(?, resource_type), is_deleted = COALESCE(?, is_deleted)
+            WHERE id = ?
+        """, (normalized_effect, (resource_type or "").strip() or None, None if is_deleted is None else int(is_deleted), permission_id))
+        after = dict(target.execute("SELECT * FROM identity_role_permissions WHERE id = ?", (permission_id,)).fetchone())
+        _identity_audit(target, event_type="identity_role_permission.update", tenant_id=after["tenant_id"], actor_principal_type=actor_principal_type, actor_principal_id=actor_principal_id, resource_type="identity_role", resource_id=after["role_id"], summary=f"Updated role permission {permission_id}", before=before, after=after)
+        return True
+    if conn is not None:
+        return _update(conn)
+    with db_session() as active_conn:
+        return _update(active_conn)
+
+
+def update_identity_role_assignment(assignment_id: str, *, expires_at: str | None = None, is_deleted: bool | None = None, actor_principal_type: str | None = None, actor_principal_id: str | None = None, conn: sqlite3.Connection | None = None) -> bool:
+    def _update(target: sqlite3.Connection) -> bool:
+        before_row = target.execute("SELECT * FROM identity_role_assignments WHERE id = ?", (assignment_id,)).fetchone()
+        if not before_row:
+            return False
+        before = dict(before_row)
+        target.execute("""
+            UPDATE identity_role_assignments
+            SET expires_at = COALESCE(?, expires_at), is_deleted = COALESCE(?, is_deleted)
+            WHERE id = ?
+        """, (expires_at, None if is_deleted is None else int(is_deleted), assignment_id))
+        after = dict(target.execute("SELECT * FROM identity_role_assignments WHERE id = ?", (assignment_id,)).fetchone())
+        _identity_audit(target, event_type="identity_role_assignment.update", tenant_id=after["tenant_id"], actor_principal_type=actor_principal_type, actor_principal_id=actor_principal_id, resource_type="identity_role", resource_id=after["role_id"], summary=f"Updated role assignment {assignment_id}", before=before, after=after)
+        return True
+    if conn is not None:
+        return _update(conn)
+    with db_session() as active_conn:
+        return _update(active_conn)
+
 
 def ensure_parent_dir(p: Path) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)

--- a/server/db_helpers.py
+++ b/server/db_helpers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, Iterator
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-SCHEMA_VERSION = 25
+SCHEMA_VERSION = 26
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT / "data"
@@ -202,6 +202,153 @@ def ensure_resource_ownership_columns(
         conn.execute(
             f"CREATE INDEX IF NOT EXISTS idx_{table}_visibility ON {table}(visibility)"
         )
+
+def ensure_access_control_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS access_control_entries (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            resource_type TEXT NOT NULL,
+            resource_id TEXT NOT NULL,
+            principal_type TEXT NOT NULL,
+            principal_id TEXT NOT NULL,
+            effect TEXT NOT NULL CHECK(effect IN ('allow', 'deny')),
+            action TEXT NOT NULL,
+            scope TEXT NOT NULL DEFAULT 'resource',
+            inherited_from_type TEXT,
+            inherited_from_id TEXT,
+            reason TEXT,
+            created_by_principal_type TEXT,
+            created_by_principal_id TEXT,
+            created_at TEXT NOT NULL,
+            expires_at TEXT,
+            is_deleted INTEGER NOT NULL DEFAULT 0
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_ace_resource_action
+            ON access_control_entries(tenant_id, resource_type, resource_id, action, is_deleted);
+        CREATE INDEX IF NOT EXISTS idx_ace_principal_action
+            ON access_control_entries(tenant_id, principal_type, principal_id, action, is_deleted);
+        CREATE INDEX IF NOT EXISTS idx_ace_effect
+            ON access_control_entries(effect, is_deleted);
+        CREATE INDEX IF NOT EXISTS idx_ace_inherited_from
+            ON access_control_entries(inherited_from_type, inherited_from_id);
+        CREATE INDEX IF NOT EXISTS idx_ace_expires_at
+            ON access_control_entries(expires_at);
+        """
+    )
+
+def _required_acl_value(name: str, value: str | None) -> str:
+    cleaned = (value or "").strip()
+    if not cleaned:
+        raise ValueError(f"{name} is required")
+    return cleaned
+
+def create_access_control_entry(
+    *,
+    resource_type: str,
+    resource_id: str,
+    principal_type: str,
+    principal_id: str,
+    effect: str,
+    action: str,
+    tenant_id: str = "default",
+    scope: str = "resource",
+    inherited_from_type: str | None = None,
+    inherited_from_id: str | None = None,
+    reason: str | None = None,
+    created_by_principal_type: str | None = None,
+    created_by_principal_id: str | None = None,
+    expires_at: str | None = None,
+    conn: sqlite3.Connection | None = None,
+) -> str:
+    normalized_effect = _required_acl_value("effect", effect).lower()
+    if normalized_effect not in {"allow", "deny"}:
+        raise ValueError("effect must be 'allow' or 'deny'")
+
+    ace_id = new_uuid()
+    values = (
+        ace_id,
+        (tenant_id or "default").strip() or "default",
+        _required_acl_value("resource_type", resource_type),
+        _required_acl_value("resource_id", resource_id),
+        _required_acl_value("principal_type", principal_type),
+        _required_acl_value("principal_id", principal_id),
+        normalized_effect,
+        _required_acl_value("action", action),
+        (scope or "resource").strip() or "resource",
+        (inherited_from_type or "").strip() or None,
+        (inherited_from_id or "").strip() or None,
+        (reason or "").strip() or None,
+        (created_by_principal_type or "").strip() or None,
+        (created_by_principal_id or "").strip() or None,
+        _utc_now_iso(),
+        (expires_at or "").strip() or None,
+    )
+
+    def _insert(target: sqlite3.Connection) -> None:
+        target.execute(
+            """
+            INSERT INTO access_control_entries (
+                id, tenant_id, resource_type, resource_id, principal_type, principal_id,
+                effect, action, scope, inherited_from_type, inherited_from_id, reason,
+                created_by_principal_type, created_by_principal_id, created_at, expires_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            values,
+        )
+
+    if conn is not None:
+        _insert(conn)
+    else:
+        with db_session() as sconn:
+            _insert(sconn)
+    return ace_id
+
+def list_access_control_entries(
+    *,
+    tenant_id: str | None = None,
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+    principal_type: str | None = None,
+    principal_id: str | None = None,
+    action: str | None = None,
+    include_deleted: bool = False,
+    conn: sqlite3.Connection | None = None,
+) -> list[dict]:
+    where: list[str] = []
+    params: list[Any] = []
+
+    for column, value in (
+        ("tenant_id", tenant_id),
+        ("resource_type", resource_type),
+        ("resource_id", resource_id),
+        ("principal_type", principal_type),
+        ("principal_id", principal_id),
+        ("action", action),
+    ):
+        cleaned = (value or "").strip()
+        if cleaned:
+            where.append(f"{column} = ?")
+            params.append(cleaned)
+
+    if not include_deleted:
+        where.append("is_deleted = 0")
+
+    sql = "SELECT * FROM access_control_entries"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY created_at ASC, id ASC"
+
+    def _fetch(target: sqlite3.Connection) -> list[dict]:
+        return [dict(row) for row in target.execute(sql, params).fetchall()]
+
+    if conn is not None:
+        return _fetch(conn)
+    with db_session() as sconn:
+        return _fetch(sconn)
 
 def ensure_parent_dir(p: Path) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)

--- a/server/db_helpers.py
+++ b/server/db_helpers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, Iterator
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-SCHEMA_VERSION = 24
+SCHEMA_VERSION = 25
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT / "data"
@@ -148,6 +148,60 @@ def get_audit_event(audit_id: str, conn: sqlite3.Connection | None = None) -> di
         return _fetch(conn)
     with db_session() as sconn:
         return _fetch(sconn)
+
+_OWNED_RESOURCE_TABLES = (
+    "projects",
+    "conversations",
+    "messages",
+    "memories",
+    "files",
+    "artifacts",
+)
+
+def ensure_resource_ownership_columns(
+    conn: sqlite3.Connection,
+    tables: Iterable[str] = _OWNED_RESOURCE_TABLES,
+) -> None:
+    for table in tables:
+        if not table or not _VALID_TABLE.match(table):
+            raise ValueError(f"Unsafe table name: {table!r}")
+        if not _table_exists(conn, table):
+            continue
+        _add_column_if_missing(conn, table, "tenant_id", "TEXT NOT NULL DEFAULT 'default'")
+        _add_column_if_missing(conn, table, "owner_principal_type", "TEXT")
+        _add_column_if_missing(conn, table, "owner_principal_id", "TEXT")
+        _add_column_if_missing(conn, table, "created_by_principal_type", "TEXT")
+        _add_column_if_missing(conn, table, "created_by_principal_id", "TEXT")
+        _add_column_if_missing(conn, table, "source_principal_type", "TEXT")
+        _add_column_if_missing(conn, table, "source_principal_id", "TEXT")
+        _add_column_if_missing(conn, table, "visibility", "TEXT NOT NULL DEFAULT 'private'")
+        _add_column_if_missing(conn, table, "sharing_mode", "TEXT NOT NULL DEFAULT 'owner'")
+        _add_column_if_missing(conn, table, "provenance_json", "TEXT")
+
+        conn.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_{table}_tenant_id ON {table}(tenant_id)"
+        )
+        conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS idx_{table}_owner_principal
+                ON {table}(owner_principal_type, owner_principal_id)
+            """
+        )
+        conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS idx_{table}_created_by_principal
+                ON {table}(created_by_principal_type, created_by_principal_id)
+            """
+        )
+        conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS idx_{table}_source_principal
+                ON {table}(source_principal_type, source_principal_id)
+            """
+        )
+        conn.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_{table}_visibility ON {table}(visibility)"
+        )
 
 def ensure_parent_dir(p: Path) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)

--- a/server/db_helpers.py
+++ b/server/db_helpers.py
@@ -34,6 +34,14 @@ def _audit_metadata_json(metadata: Any | None) -> str | None:
         return value or None
     return json.dumps(metadata, ensure_ascii=False, sort_keys=True)
 
+def _audit_json(value: Any | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return cleaned or None
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
 def ensure_audit_events_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(
         """
@@ -45,9 +53,14 @@ def ensure_audit_events_schema(conn: sqlite3.Connection) -> None:
             actor_principal_id TEXT,
             resource_type TEXT,
             resource_id TEXT,
+            target_principal_type TEXT,
+            target_principal_id TEXT,
             action TEXT,
             decision TEXT,
             reason TEXT,
+            summary TEXT,
+            before_json TEXT,
+            after_json TEXT,
             request_id TEXT,
             source_ip TEXT,
             user_agent TEXT,
@@ -67,6 +80,17 @@ def ensure_audit_events_schema(conn: sqlite3.Connection) -> None:
             ON audit_events(request_id);
         """
     )
+    _add_column_if_missing(conn, "audit_events", "target_principal_type", "TEXT")
+    _add_column_if_missing(conn, "audit_events", "target_principal_id", "TEXT")
+    _add_column_if_missing(conn, "audit_events", "summary", "TEXT")
+    _add_column_if_missing(conn, "audit_events", "before_json", "TEXT")
+    _add_column_if_missing(conn, "audit_events", "after_json", "TEXT")
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_audit_events_target
+            ON audit_events(target_principal_type, target_principal_id, created_at)
+        """
+    )
 
 def log_audit_event(
     *,
@@ -76,9 +100,14 @@ def log_audit_event(
     actor_principal_id: str | None = None,
     resource_type: str | None = None,
     resource_id: str | None = None,
+    target_principal_type: str | None = None,
+    target_principal_id: str | None = None,
     action: str | None = None,
     decision: str | None = None,
     reason: str | None = None,
+    summary: str | None = None,
+    before: Any | None = None,
+    after: Any | None = None,
     request_id: str | None = None,
     source_ip: str | None = None,
     user_agent: str | None = None,
@@ -99,9 +128,14 @@ def log_audit_event(
         (actor_principal_id or "").strip() or None,
         (resource_type or "").strip() or None,
         (resource_id or "").strip() or None,
+        (target_principal_type or "").strip() or None,
+        (target_principal_id or "").strip() or None,
         (action or "").strip() or None,
         (decision or "").strip() or None,
         (reason or "").strip() or None,
+        (summary or "").strip() or None,
+        _audit_json(before),
+        _audit_json(after),
         (request_id or "").strip() or None,
         (source_ip or "").strip() or None,
         (user_agent or "").strip() or None,
@@ -114,10 +148,11 @@ def log_audit_event(
             """
             INSERT INTO audit_events (
                 id, tenant_id, event_type, actor_principal_type, actor_principal_id,
-                resource_type, resource_id, action, decision, reason, request_id,
+                resource_type, resource_id, target_principal_type, target_principal_id,
+                action, decision, reason, summary, before_json, after_json, request_id,
                 source_ip, user_agent, metadata_json, created_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             values,
         )

--- a/server/db_helpers.py
+++ b/server/db_helpers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, Iterator
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-SCHEMA_VERSION = 26
+SCHEMA_VERSION = 27
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT / "data"
@@ -349,6 +349,82 @@ def list_access_control_entries(
         return _fetch(conn)
     with db_session() as sconn:
         return _fetch(sconn)
+
+def ensure_identity_group_role_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS identity_groups (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            name TEXT NOT NULL,
+            display_name TEXT,
+            description TEXT,
+            created_by_principal_type TEXT,
+            created_by_principal_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(tenant_id, name)
+        );
+
+        CREATE TABLE IF NOT EXISTS identity_group_members (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            group_id TEXT NOT NULL,
+            member_principal_type TEXT NOT NULL,
+            member_principal_id TEXT NOT NULL,
+            added_by_principal_type TEXT,
+            added_by_principal_id TEXT,
+            created_at TEXT NOT NULL,
+            expires_at TEXT,
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY(group_id) REFERENCES identity_groups(id) ON DELETE CASCADE,
+            UNIQUE(tenant_id, group_id, member_principal_type, member_principal_id, is_deleted)
+        );
+
+        CREATE TABLE IF NOT EXISTS identity_roles (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            name TEXT NOT NULL,
+            display_name TEXT,
+            description TEXT,
+            created_by_principal_type TEXT,
+            created_by_principal_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(tenant_id, name)
+        );
+
+        CREATE TABLE IF NOT EXISTS identity_role_assignments (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            role_id TEXT NOT NULL,
+            principal_type TEXT NOT NULL,
+            principal_id TEXT NOT NULL,
+            granted_by_principal_type TEXT,
+            granted_by_principal_id TEXT,
+            created_at TEXT NOT NULL,
+            expires_at TEXT,
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY(role_id) REFERENCES identity_roles(id) ON DELETE CASCADE,
+            UNIQUE(tenant_id, role_id, principal_type, principal_id, is_deleted)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_identity_groups_tenant
+            ON identity_groups(tenant_id, is_deleted);
+        CREATE INDEX IF NOT EXISTS idx_identity_group_members_group
+            ON identity_group_members(tenant_id, group_id, is_deleted);
+        CREATE INDEX IF NOT EXISTS idx_identity_group_members_member
+            ON identity_group_members(tenant_id, member_principal_type, member_principal_id, is_deleted);
+        CREATE INDEX IF NOT EXISTS idx_identity_roles_tenant
+            ON identity_roles(tenant_id, is_deleted);
+        CREATE INDEX IF NOT EXISTS idx_identity_role_assignments_role
+            ON identity_role_assignments(tenant_id, role_id, is_deleted);
+        CREATE INDEX IF NOT EXISTS idx_identity_role_assignments_principal
+            ON identity_role_assignments(tenant_id, principal_type, principal_id, is_deleted);
+        """
+    )
 
 def ensure_parent_dir(p: Path) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)

--- a/server/db_helpers.py
+++ b/server/db_helpers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, Iterator
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-SCHEMA_VERSION = 28
+SCHEMA_VERSION = 29
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT / "data"
@@ -187,22 +187,82 @@ def get_audit_event(audit_id: str, conn: sqlite3.Connection | None = None) -> di
 _OWNED_RESOURCE_TABLES = (
     "projects",
     "conversations",
-    "messages",
     "memories",
     "files",
     "artifacts",
+    "personas",
+    "user_profiles",
 )
+
+_MESSAGE_IDENTITY_TABLES = ("messages",)
+
+_OWNED_RESOURCE_ID_COLUMNS = {
+    "projects": "id",
+    "conversations": "id",
+    "memories": "id",
+    "files": "id",
+    "artifacts": "id",
+    "personas": "id",
+    "user_profiles": "id",
+}
+
+
+def ensure_identity_resource_tables(conn: sqlite3.Connection) -> None:
+    now = _utc_now_iso()
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS personas (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            display_name TEXT NOT NULL,
+            description TEXT,
+            is_active INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS user_profiles (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            user_id TEXT NOT NULL,
+            display_name TEXT NOT NULL,
+            profile_json TEXT,
+            about_text TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            UNIQUE(tenant_id, user_id)
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO personas (id, tenant_id, display_name, description, created_at, updated_at)
+        VALUES ('assistant', 'default', 'Doc Tomiko', 'Default local assistant persona', ?, ?)
+        """,
+        (now, now),
+    )
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO user_profiles (id, tenant_id, user_id, display_name, profile_json, about_text, created_at, updated_at)
+        VALUES ('local', 'default', 'local', 'Doc', NULL, NULL, ?, ?)
+        """,
+        (now, now),
+    )
 
 def ensure_resource_ownership_columns(
     conn: sqlite3.Connection,
     tables: Iterable[str] = _OWNED_RESOURCE_TABLES,
 ) -> None:
+    ensure_identity_resource_tables(conn)
     for table in tables:
         if not table or not _VALID_TABLE.match(table):
             raise ValueError(f"Unsafe table name: {table!r}")
         if not _table_exists(conn, table):
             continue
         _add_column_if_missing(conn, table, "tenant_id", "TEXT NOT NULL DEFAULT 'default'")
+        _add_column_if_missing(conn, table, "owner_user_id", "TEXT NOT NULL DEFAULT 'local'")
+        _add_column_if_missing(conn, table, "created_by_user_id", "TEXT NOT NULL DEFAULT 'local'")
+        _add_column_if_missing(conn, table, "updated_by_user_id", "TEXT NOT NULL DEFAULT 'local'")
         _add_column_if_missing(conn, table, "owner_principal_type", "TEXT")
         _add_column_if_missing(conn, table, "owner_principal_id", "TEXT")
         _add_column_if_missing(conn, table, "created_by_principal_type", "TEXT")
@@ -214,7 +274,30 @@ def ensure_resource_ownership_columns(
         _add_column_if_missing(conn, table, "provenance_json", "TEXT")
 
         conn.execute(
+            f"""
+            UPDATE {table}
+            SET
+                owner_user_id = COALESCE(NULLIF(TRIM(owner_user_id), ''), 'local'),
+                created_by_user_id = COALESCE(NULLIF(TRIM(created_by_user_id), ''), 'local'),
+                updated_by_user_id = COALESCE(NULLIF(TRIM(updated_by_user_id), ''), created_by_user_id, owner_user_id, 'local'),
+                owner_principal_type = COALESCE(NULLIF(TRIM(owner_principal_type), ''), 'user'),
+                owner_principal_id = COALESCE(NULLIF(TRIM(owner_principal_id), ''), owner_user_id, 'local'),
+                created_by_principal_type = COALESCE(NULLIF(TRIM(created_by_principal_type), ''), 'user'),
+                created_by_principal_id = COALESCE(NULLIF(TRIM(created_by_principal_id), ''), created_by_user_id, 'local')
+            """
+        )
+
+        conn.execute(
             f"CREATE INDEX IF NOT EXISTS idx_{table}_tenant_id ON {table}(tenant_id)"
+        )
+        conn.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_{table}_owner_user_id ON {table}(owner_user_id)"
+        )
+        conn.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_{table}_created_by_user_id ON {table}(created_by_user_id)"
+        )
+        conn.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_{table}_updated_by_user_id ON {table}(updated_by_user_id)"
         )
         conn.execute(
             f"""
@@ -237,6 +320,118 @@ def ensure_resource_ownership_columns(
         conn.execute(
             f"CREATE INDEX IF NOT EXISTS idx_{table}_visibility ON {table}(visibility)"
         )
+
+    ensure_message_identity_columns(conn)
+
+
+def ensure_message_identity_columns(conn: sqlite3.Connection) -> None:
+    for table in _MESSAGE_IDENTITY_TABLES:
+        if not _table_exists(conn, table):
+            continue
+        _add_column_if_missing(conn, table, "tenant_id", "TEXT NOT NULL DEFAULT 'default'")
+        _add_column_if_missing(conn, table, "created_by_principal_type", "TEXT")
+        _add_column_if_missing(conn, table, "created_by_principal_id", "TEXT")
+        _add_column_if_missing(conn, table, "source_principal_type", "TEXT")
+        _add_column_if_missing(conn, table, "source_principal_id", "TEXT")
+        _add_column_if_missing(conn, table, "visibility", "TEXT NOT NULL DEFAULT 'inherit'")
+        _add_column_if_missing(conn, table, "sharing_mode", "TEXT NOT NULL DEFAULT 'inherit'")
+        _add_column_if_missing(conn, table, "provenance_json", "TEXT")
+        conn.execute(f"CREATE INDEX IF NOT EXISTS idx_{table}_tenant_id ON {table}(tenant_id)")
+        conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS idx_{table}_source_principal
+                ON {table}(source_principal_type, source_principal_id)
+            """
+        )
+
+def transfer_resource_ownership(
+    *,
+    resource_type: str,
+    resource_id: str,
+    owner_user_id: str,
+    updated_by_user_id: str = "local",
+    tenant_id: str = "default",
+    conn: sqlite3.Connection | None = None,
+) -> bool:
+    table = (resource_type or "").strip()
+    if table == "project":
+        table = "projects"
+    elif table == "conversation":
+        table = "conversations"
+    elif table == "memory":
+        table = "memories"
+    elif table == "file":
+        table = "files"
+    elif table == "artifact":
+        table = "artifacts"
+    elif table == "persona":
+        table = "personas"
+    elif table == "user_profile":
+        table = "user_profiles"
+
+    if table not in _OWNED_RESOURCE_ID_COLUMNS:
+        raise ValueError(f"Unsupported owned resource type: {resource_type}")
+    owner_user_id = (owner_user_id or "").strip()
+    if not owner_user_id:
+        raise ValueError("owner_user_id is required")
+    updated_by_user_id = (updated_by_user_id or "local").strip() or "local"
+    id_column = _OWNED_RESOURCE_ID_COLUMNS[table]
+    now = _utc_now_iso()
+
+    def _transfer(target: sqlite3.Connection) -> bool:
+        row = target.execute(
+            f"SELECT * FROM {table} WHERE {id_column} = ?",
+            (str(resource_id),),
+        ).fetchone()
+        if row is None and table == "projects":
+            row = target.execute(
+                f"SELECT * FROM {table} WHERE {id_column} = ?",
+                (int(resource_id),),
+            ).fetchone()
+        if row is None:
+            return False
+        before = dict(row)
+        target.execute(
+            f"""
+            UPDATE {table}
+            SET
+                owner_user_id = ?,
+                updated_by_user_id = ?,
+                owner_principal_type = 'user',
+                owner_principal_id = ?,
+                updated_at = COALESCE(?, updated_at)
+            WHERE {id_column} = ?
+            """,
+            (owner_user_id, updated_by_user_id, owner_user_id, now, row[id_column]),
+        )
+        after = target.execute(
+            f"SELECT * FROM {table} WHERE {id_column} = ?",
+            (row[id_column],),
+        ).fetchone()
+        ensure_audit_events_schema(target)
+        log_audit_event(
+            event_type="ownership.transfer",
+            tenant_id=tenant_id,
+            actor_principal_type="user",
+            actor_principal_id=updated_by_user_id,
+            resource_type=resource_type,
+            resource_id=str(resource_id),
+            target_principal_type="user",
+            target_principal_id=owner_user_id,
+            action="transfer_ownership",
+            summary=f"Transferred {resource_type} ownership to {owner_user_id}",
+            before=before,
+            after=dict(after) if after else None,
+            conn=target,
+            raise_on_error=True,
+        )
+        return True
+
+    if conn is not None:
+        return _transfer(conn)
+    with db_session() as active_conn:
+        return _transfer(active_conn)
+
 
 def ensure_access_control_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(

--- a/server/db_helpers.py
+++ b/server/db_helpers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, Iterator
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
-SCHEMA_VERSION = 29
+SCHEMA_VERSION = 30
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT / "data"

--- a/server/db_helpers.py
+++ b/server/db_helpers.py
@@ -469,11 +469,55 @@ def ensure_access_control_schema(conn: sqlite3.Connection) -> None:
         """
     )
 
+_VALID_ACE_EFFECTS = {"allow", "deny"}
+_VALID_ACE_PRINCIPAL_TYPES = {
+    "user",
+    "group",
+    "role",
+    "persona",
+    "tenant_users",
+    "tenant_personas",
+    "public",
+    "service",
+}
+_VALID_ACE_ACTIONS = {
+    "view",
+    "edit",
+    "archive",
+    "soft_remove",
+    "permanent_remove",
+    "restore",
+    "share",
+    "manage",
+    "use_in_context",
+    # Compatibility aliases used by the first resolver implementation.
+    "read",
+    "write",
+    "delete",
+    "admin",
+    "audit",
+}
+
+
 def _required_acl_value(name: str, value: str | None) -> str:
     cleaned = (value or "").strip()
     if not cleaned:
         raise ValueError(f"{name} is required")
     return cleaned
+
+
+def _validate_ace_principal_type(value: str) -> str:
+    principal_type = _required_acl_value("principal_type", value).lower()
+    if principal_type not in _VALID_ACE_PRINCIPAL_TYPES:
+        raise ValueError(f"principal_type must be one of {sorted(_VALID_ACE_PRINCIPAL_TYPES)}")
+    return principal_type
+
+
+def _validate_ace_action(value: str) -> str:
+    action = _required_acl_value("action", value).lower()
+    if action not in _VALID_ACE_ACTIONS:
+        raise ValueError(f"action must be one of {sorted(_VALID_ACE_ACTIONS)}")
+    return action
 
 def create_access_control_entry(
     *,
@@ -494,8 +538,10 @@ def create_access_control_entry(
     conn: sqlite3.Connection | None = None,
 ) -> str:
     normalized_effect = _required_acl_value("effect", effect).lower()
-    if normalized_effect not in {"allow", "deny"}:
+    if normalized_effect not in _VALID_ACE_EFFECTS:
         raise ValueError("effect must be 'allow' or 'deny'")
+    normalized_principal_type = _validate_ace_principal_type(principal_type)
+    normalized_action = _validate_ace_action(action)
 
     ace_id = new_uuid()
     values = (
@@ -503,10 +549,10 @@ def create_access_control_entry(
         (tenant_id or "default").strip() or "default",
         _required_acl_value("resource_type", resource_type),
         _required_acl_value("resource_id", resource_id),
-        _required_acl_value("principal_type", principal_type),
+        normalized_principal_type,
         _required_acl_value("principal_id", principal_id),
         normalized_effect,
-        _required_acl_value("action", action),
+        normalized_action,
         (scope or "resource").strip() or "resource",
         (inherited_from_type or "").strip() or None,
         (inherited_from_id or "").strip() or None,
@@ -529,6 +575,24 @@ def create_access_control_entry(
             """,
             values,
         )
+        row = target.execute("SELECT * FROM access_control_entries WHERE id = ?", (ace_id,)).fetchone()
+        ensure_audit_events_schema(target)
+        log_audit_event(
+            event_type="access_control_entry.create",
+            tenant_id=values[1],
+            actor_principal_type=values[12],
+            actor_principal_id=values[13],
+            resource_type=values[2],
+            resource_id=values[3],
+            target_principal_type=values[4],
+            target_principal_id=values[5],
+            action=values[7],
+            decision=values[6],
+            summary=f"Created {values[6]} ACE for {values[4]}:{values[5]}",
+            after=dict(row) if row else None,
+            conn=target,
+            raise_on_error=True,
+        )
 
     if conn is not None:
         _insert(conn)
@@ -536,6 +600,61 @@ def create_access_control_entry(
         with db_session() as sconn:
             _insert(sconn)
     return ace_id
+
+def remove_access_control_entry(
+    ace_id: str,
+    *,
+    deleted_by_principal_type: str | None = None,
+    deleted_by_principal_id: str | None = None,
+    conn: sqlite3.Connection | None = None,
+) -> bool:
+    ace_id = _required_acl_value("ace_id", ace_id)
+    actor_type = (deleted_by_principal_type or "user").strip() or "user"
+    actor_id = (deleted_by_principal_id or "local").strip() or "local"
+
+    def _remove(target: sqlite3.Connection) -> bool:
+        row = target.execute(
+            "SELECT * FROM access_control_entries WHERE id = ?",
+            (ace_id,),
+        ).fetchone()
+        if not row:
+            return False
+        before = dict(row)
+        if int(row["is_deleted"] or 0):
+            return True
+        target.execute(
+            "UPDATE access_control_entries SET is_deleted = 1 WHERE id = ?",
+            (ace_id,),
+        )
+        after = target.execute(
+            "SELECT * FROM access_control_entries WHERE id = ?",
+            (ace_id,),
+        ).fetchone()
+        ensure_audit_events_schema(target)
+        log_audit_event(
+            event_type="access_control_entry.remove",
+            tenant_id=row["tenant_id"] or "default",
+            actor_principal_type=actor_type,
+            actor_principal_id=actor_id,
+            resource_type=row["resource_type"],
+            resource_id=row["resource_id"],
+            target_principal_type=row["principal_type"],
+            target_principal_id=row["principal_id"],
+            action=row["action"],
+            decision=row["effect"],
+            summary=f"Removed ACE {ace_id}",
+            before=before,
+            after=dict(after) if after else None,
+            conn=target,
+            raise_on_error=True,
+        )
+        return True
+
+    if conn is not None:
+        return _remove(conn)
+    with db_session() as active_conn:
+        return _remove(active_conn)
+
 
 def list_access_control_entries(
     *,

--- a/server/main.py
+++ b/server/main.py
@@ -27,6 +27,7 @@ import server.routes.library  # noqa: F401
 import server.routes.memories  # noqa: F401
 import server.routes.projects  # noqa: F401
 import server.routes.search  # noqa: F401
+import server.routes.sharing  # noqa: F401
 import server.routes.tooling  # noqa: F401
 
 __all__ = ["app"]

--- a/server/routes/memories.py
+++ b/server/routes/memories.py
@@ -38,6 +38,8 @@ def api_create_memory(req: MemoryCreate):
             origin_kind=req.origin_kind,
             scope_type=req.scope_type,
             scope_id=req.scope_id,
+            persona_id=req.persona_id,
+            persona_context_mode=req.persona_context_mode,
         )
         invalidate_all_context_cache()
         return JSONResponse(mem)
@@ -57,6 +59,8 @@ def api_update_memory(memory_id: str, req: MemoryUpdate):
             origin_kind=req.origin_kind,
             scope_type=req.scope_type,
             scope_id=req.scope_id,
+            persona_id=req.persona_id,
+            persona_context_mode=req.persona_context_mode,
         )
         invalidate_all_context_cache()
         return JSONResponse(mem)

--- a/server/routes/memories.py
+++ b/server/routes/memories.py
@@ -39,6 +39,8 @@ def api_create_memory(req: MemoryCreate):
             scope_type=req.scope_type,
             scope_id=req.scope_id,
             persona_id=req.persona_id,
+            persona_ids=req.persona_ids,
+            persona_scope=req.persona_scope,
             persona_context_mode=req.persona_context_mode,
         )
         invalidate_all_context_cache()
@@ -60,6 +62,8 @@ def api_update_memory(memory_id: str, req: MemoryUpdate):
             scope_type=req.scope_type,
             scope_id=req.scope_id,
             persona_id=req.persona_id,
+            persona_ids=req.persona_ids,
+            persona_scope=req.persona_scope,
             persona_context_mode=req.persona_context_mode,
         )
         invalidate_all_context_cache()

--- a/server/routes/sharing.py
+++ b/server/routes/sharing.py
@@ -9,6 +9,8 @@ from server.db import (
     db_get_memory_access_resource,
     db_get_message_access_resource,
     db_get_project_access_resource,
+    db_get_user_profile_access_resource,
+    db_get_effective_sharing_source,
 )
 from server.db_helpers import db_session, list_access_control_entries
 from server.routes.base import app
@@ -21,7 +23,44 @@ _RESOURCE_LOADERS = {
     "memory": db_get_memory_access_resource,
     "message": db_get_message_access_resource,
     "project": db_get_project_access_resource,
+    "user_profile": db_get_user_profile_access_resource,
 }
+
+
+def _principal_memberships(conn, principal: dict) -> dict:
+    tenant_id = principal.get("tenant_id") or "default"
+    principal_type = principal.get("principal_type") or "user"
+    principal_id = principal.get("principal_id") or "local"
+    groups = [
+        dict(row)
+        for row in conn.execute(
+            """
+            SELECT gm.*, g.name AS group_name
+            FROM identity_group_members gm
+            LEFT JOIN identity_groups g ON g.id = gm.group_id
+            WHERE gm.tenant_id = ?
+              AND gm.member_principal_type = ?
+              AND gm.member_principal_id = ?
+              AND gm.is_deleted = 0
+            """,
+            (tenant_id, principal_type, principal_id),
+        ).fetchall()
+    ]
+    group_ids = [row["group_id"] for row in groups]
+    params = [tenant_id, principal_type, principal_id, *group_ids]
+    role_sql = """
+        SELECT ra.*, r.name AS role_name
+        FROM identity_role_assignments ra
+        LEFT JOIN identity_roles r ON r.id = ra.role_id
+        WHERE ra.tenant_id IN (?, 'global')
+          AND ra.is_deleted = 0
+          AND ((ra.principal_type = ? AND ra.principal_id = ?)
+    """
+    if group_ids:
+        role_sql += " OR (ra.principal_type = 'group' AND ra.principal_id IN (" + ",".join("?" for _ in group_ids) + "))"
+    role_sql += ")"
+    roles = [dict(row) for row in conn.execute(role_sql, params).fetchall()]
+    return {"groups": groups, "roles": roles}
 
 
 def _resource_for(resource_type: str, resource_id: str) -> dict:
@@ -57,6 +96,22 @@ def api_sharing_diagnostics(
 
     with db_session() as conn:
         decision = resolve_access(principal, resource, action, explain=True, conn=conn)
+        memberships = _principal_memberships(conn, principal)
+        effective_source = db_get_effective_sharing_source(resource["resource_type"], resource["resource_id"])
+        persona_context_decision = None
+        if resource["resource_type"] in {"memory", "user_profile"}:
+            persona_principal = {
+                "principal_type": "persona",
+                "principal_id": principal_id if principal_type == "persona" else "assistant",
+                "tenant_id": principal["tenant_id"],
+            }
+            persona_context_decision = resolve_access(
+                persona_principal,
+                resource,
+                "use_in_context",
+                explain=True,
+                conn=conn,
+            ).to_dict()
         direct_entries = list_access_control_entries(
             conn=conn,
             tenant_id=resource.get("tenant_id") or "default",
@@ -82,6 +137,14 @@ def api_sharing_diagnostics(
             "principal": principal,
             "action": action,
             "decision": decision.to_dict(),
+            "persona_context_decision": persona_context_decision,
+            "effective_sharing_source": effective_source,
+            "principal_memberships": memberships,
+            "default_chain": {
+                "resource_visibility": resource.get("visibility"),
+                "tenant_policy": decision.to_dict().get("policy"),
+                "inherited_from": resource.get("inherited_from") or [],
+            },
             "direct_access_control_entries": direct_entries,
             "inherited_access_control_entries": inherited_entries,
         }

--- a/server/routes/sharing.py
+++ b/server/routes/sharing.py
@@ -1,0 +1,88 @@
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+from server.access_control import resolve_access
+from server.db import (
+    db_get_artifact_access_resource,
+    db_get_conversation_access_resource,
+    db_get_file_access_resource,
+    db_get_memory_access_resource,
+    db_get_message_access_resource,
+    db_get_project_access_resource,
+)
+from server.db_helpers import db_session, list_access_control_entries
+from server.routes.base import app
+
+
+_RESOURCE_LOADERS = {
+    "artifact": db_get_artifact_access_resource,
+    "conversation": db_get_conversation_access_resource,
+    "file": db_get_file_access_resource,
+    "memory": db_get_memory_access_resource,
+    "message": db_get_message_access_resource,
+    "project": db_get_project_access_resource,
+}
+
+
+def _resource_for(resource_type: str, resource_id: str) -> dict:
+    resource_type = (resource_type or "").strip().lower()
+    resource_id = (resource_id or "").strip()
+    loader = _RESOURCE_LOADERS.get(resource_type)
+    if not loader:
+        raise HTTPException(status_code=400, detail=f"Unsupported resource_type: {resource_type}")
+    try:
+        resource = loader(int(resource_id)) if resource_type in {"message", "project"} else loader(resource_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if not resource:
+        raise HTTPException(status_code=404, detail="Resource not found.")
+    return resource
+
+
+@app.get("/api/sharing/diagnostics")
+def api_sharing_diagnostics(
+    resource_type: str,
+    resource_id: str,
+    action: str = "read",
+    principal_type: str = "user",
+    principal_id: str = "local",
+    tenant_id: str | None = None,
+):
+    resource = _resource_for(resource_type, resource_id)
+    principal = {
+        "principal_type": principal_type,
+        "principal_id": principal_id,
+        "tenant_id": tenant_id or resource.get("tenant_id") or "default",
+    }
+
+    with db_session() as conn:
+        decision = resolve_access(principal, resource, action, explain=True, conn=conn)
+        direct_entries = list_access_control_entries(
+            conn=conn,
+            tenant_id=resource.get("tenant_id") or "default",
+            resource_type=resource["resource_type"],
+            resource_id=resource["resource_id"],
+            include_deleted=False,
+        )
+        inherited_entries = []
+        for parent in resource.get("inherited_from") or []:
+            inherited_entries.extend(
+                list_access_control_entries(
+                    conn=conn,
+                    tenant_id=resource.get("tenant_id") or "default",
+                    resource_type=parent.get("resource_type"),
+                    resource_id=parent.get("resource_id"),
+                    include_deleted=False,
+                )
+            )
+
+    return JSONResponse(
+        {
+            "resource": resource,
+            "principal": principal,
+            "action": action,
+            "decision": decision.to_dict(),
+            "direct_access_control_entries": direct_entries,
+            "inherited_access_control_entries": inherited_entries,
+        }
+    )

--- a/server/static/app.events.js
+++ b/server/static/app.events.js
@@ -301,6 +301,14 @@ if (aboutYouSaveBtn) {
     }
   });
 }
+if (aboutYouSharingBtn) {
+  aboutYouSharingBtn.addEventListener("click", () => {
+    openSharingDiagnostics("user_profile", "local").catch(e => {
+      console.error("openSharingDiagnostics about you failed", e);
+      alert("Failed to load sharing diagnostics.");
+    });
+  });
+}
 if (pinAddOrSaveBtn) {
   pinAddOrSaveBtn.addEventListener("click", () => {
     savePinFromUi().catch(e => console.error("savePinFromUi error", e));    

--- a/server/static/app.events.js
+++ b/server/static/app.events.js
@@ -112,6 +112,21 @@ if (projMenuCitationsBtn) {
   });
 }
 
+if (projMenuSharingBtn) {
+  projMenuSharingBtn.addEventListener("click", () => {
+    projMenuEl.classList.add("hidden");
+    const pid = menuTargetProjectId;
+    if (!pid) {
+      alert("No project selected.");
+      return;
+    }
+    openSharingDiagnostics("project", pid).catch(e => {
+      console.error("openSharingDiagnostics project failed", e);
+      alert("Failed to load sharing diagnostics.");
+    });
+  });
+}
+
 if (topMenuManageFilesBtn) {
   topMenuManageFilesBtn.addEventListener("click", () => {
     if (topMenuManageFilesBtn.classList.contains("files-disabled")) {
@@ -137,6 +152,21 @@ if (convMenuLibraryBtn) {
       return;
     }
     openLibraryModalForConversation(cid);
+  });
+}
+
+if (convMenuSharingBtn) {
+  convMenuSharingBtn.addEventListener("click", () => {
+    convMenuEl.classList.add("hidden");
+    const cid = menuTargetConversationId || conversationId;
+    if (!cid) {
+      alert("No conversation selected.");
+      return;
+    }
+    openSharingDiagnostics("conversation", cid).catch(e => {
+      console.error("openSharingDiagnostics conversation failed", e);
+      alert("Failed to load sharing diagnostics.");
+    });
   });
 }
 

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -58,6 +58,7 @@ const convMenuMoveToBtn = document.getElementById("menuMoveTo");
 const convMenuManageFilesBtn = document.getElementById("menuConvViewFiles");
 const convMenuLibraryBtn = document.getElementById("menuConvLibrary");
 const convMenuCitationsBtn = document.getElementById("menuConvCitations");
+const convMenuSharingBtn = document.getElementById("menuConvSharing");
 const convMenuExportTranscriptBtn = document.getElementById("menuExportTranscript");
 const convMenuSummarizeBtn = document.getElementById("menuSummarize");
 const convMenuSettingsBtn = document.getElementById("menuConvSettings");
@@ -78,6 +79,7 @@ const projMenuFileUploadBtn = document.getElementById("projUpload");
 const projMenuManageFilesBtn = document.getElementById("projFiles");
 const projMenuLibraryBtn = document.getElementById("projLibrary");
 const projMenuCitationsBtn = document.getElementById("projCitations");
+const projMenuSharingBtn = document.getElementById("projSharing");
 // #endregion
 
 // MODAL DIALOGS

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -119,6 +119,7 @@ const aboutYouAgeEl = document.getElementById("aboutYouAge");
 const aboutYouOccupationEl = document.getElementById("aboutYouOccupation");
 const aboutYouMoreEl = document.getElementById("aboutYouMore");
 const aboutYouSaveBtn = document.getElementById("saveAboutYou");
+const aboutYouSharingBtn = document.getElementById("aboutYouSharing");
 const aboutYouSectionEl = aboutYouNicknameEl ? aboutYouNicknameEl.closest(".memSection") : null;
 // Memories
 const memoryListEl = document.getElementById("memoryList");

--- a/server/static/app.manage.js
+++ b/server/static/app.manage.js
@@ -1199,6 +1199,19 @@ function openMetaInfo(title, obj) {
   metaInfoModal.classList.remove("hidden");
 }
 
+async function openSharingDiagnostics(resourceType, resourceId) {
+  if (!resourceType || !resourceId) return;
+  const params = new URLSearchParams({
+    resource_type: resourceType,
+    resource_id: String(resourceId),
+    action: "read",
+    principal_type: "user",
+    principal_id: "local",
+  });
+  const data = await fetchJsonDebug(`/api/sharing/diagnostics?${params.toString()}`);
+  openMetaInfo(`Sharing: ${resourceType} ${resourceId}`, data);
+}
+
 // #endregion
 
 // #region Debug Helpers

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -418,6 +418,7 @@
     <!-- TODO normalize the naming conventions so all start with "menuConvViewFiles" between here and app.js -->
     <button id="menuConvViewFiles">Manage files…</button>
     <button id="menuConvCitations">View citations…</button>
+    <button id="menuConvSharing">Sharing diagnostics…</button>
     <hr />
     <button id="menuArchive">Archive</button>
     <button id="menuDelete">Delete</button>
@@ -434,6 +435,7 @@
     <button id="projUpload">Add files…</button>
     <button id="projFiles">Manage files…</button>
     <button id="projCitations">View citations…</button>
+    <button id="projSharing">Sharing diagnostics…</button>
     <hr />
     <button id="projArchive">Archive</button>
     <button id="projDelete">Delete</button>

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -257,6 +257,7 @@
             </label>
             <div id="aboutYouButtonRow" class="span2">
               <button id="saveAboutYou">Save About You</button>
+              <button id="aboutYouSharing">Sharing diagnostics…</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Status

Experimental / untested stack. Do not treat this as production-ready yet.

This PR pushes the current local WyrmGPT identity/sharing/access-control work to GitHub so it can be reviewed, tested, and extended in the open instead of staying only on the server.

## Scope currently included

- Issues #2-#12 implementation stack from the ACPX burndown.
- Active queue manifest update for #13-#15.
- Local validation performed before push:
  - Python dependency venv installed locally under ignored `.venv/`.
  - `py_compile` passed for the touched server modules.
  - import smoke passed for config/db/access-control/routes/main modules.

## Known risk

- This stack has not had a full runtime/API/UI verification pass.
- Earlier ACPX completion claims were only partially verified.
- UI surfacing and permission-controlled visible surfaces are still needed to fully verify whether #2-#12 behave correctly in the product.
- The current live DB likely needs admin repair tooling because historical assets defaulted to `global_admin` ownership.

## Next work

Continue with:

- #13 admin bulk reassignment tools for ownership/provenance/sharing/persona access.
- #14 UI surfacing/editing of provenance, ownership, sharing, and persona access.
- #15 permission-controlled visible UI surfaces and admin visibility toggles.

After #13-#15, perform an end-to-end verification pass before closing #2-#15.