### PR TITLE
Fix Discord connector attachments and outage handling

### DIFF
--- a/connectors/discord-connector/callie_bot.py
+++ b/connectors/discord-connector/callie_bot.py
@@ -24,6 +24,7 @@ from guild_config import GuildConfig
 from config_manager import ConfigManager
 from helpers import _norm_content, canonical_json, now_epoch
 from openai_helpers import build_trimmed_transcript, est_tokens, openai_respond, openai_upload_file, sanitize_content, summarize_messages_block
+from outage_helpers import classify_discord_exception, classify_openai_exception, format_admin_outage
 from pk_helper import PKInfo, build_pk_context_block, format_pk_proxy_note
 from word_helpers import extract_docx_markdown, extract_text_bytes
 from access_control import AccessDecision, compute_access_decision #, ChannelReplyMode
@@ -233,7 +234,9 @@ class CallieBot(discord.Client):
         while not self._shutdown_requested.is_set():
             try:
                 log.info("Starting Discord client...")
-                await self.start(token, reconnect=True)
+                # Let our outer loop classify DNS/network failures instead of
+                # letting discord.py emit noisy reconnect tracebacks.
+                await self.start(token, reconnect=False)
 
                 # If start() returns, we were closed/logged out.
                 if self._shutdown_requested.is_set():
@@ -248,14 +251,18 @@ class CallieBot(discord.Client):
                 # DNS hiccup: back off harder, but honor shutdown.
                 if self._shutdown_requested.is_set():
                     break
-                log.warning("Discord connect failed (DNS). Retrying in %ss: %r", backoff, e)
+                outage = classify_discord_exception(e)
+                detail = format_admin_outage(outage, context="connect") if outage else f"Discord connect failed (DNS): {type(e).__name__}"
+                log.warning("%s. Retrying in %ss", detail, backoff)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 300)
 
             except OSError as e:
                 if self._shutdown_requested.is_set():
                     break
-                log.warning("Discord connect failed (network/OS). Retrying in %ss: %r", backoff, e)
+                outage = classify_discord_exception(e)
+                detail = format_admin_outage(outage, context="connect") if outage else f"Discord connect failed (network/OS): {type(e).__name__}"
+                log.warning("%s. Retrying in %ss", detail, backoff)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 300)
 
@@ -428,6 +435,8 @@ class CallieBot(discord.Client):
                     purpose="user_data",
                     api_key=api_key,
                 )
+                if file_id and not file_id.startswith("Sorry,"):
+                    extra_parts.append({"type": "input_file", "file_id": file_id})
                 attachment_notes.append(f"file uploaded: {fname} (file_id={file_id})")
             except Exception as e:
                 # Do NOT explode the whole message; just shield this attachment.
@@ -1136,10 +1145,14 @@ class CallieBot(discord.Client):
             except Exception as e:
                 response_id = ""
                 # Log full traceback to console logs, but DO NOT echo exception text to Discord
-                log.exception("OpenAI failed msg_id=%s err=%s", message.id, type(e).__name__)
+                outage = classify_openai_exception(e)
+                if outage:
+                    log.warning("%s msg_id=%s", format_admin_outage(outage, context="respond"), message.id)
+                else:
+                    log.exception("OpenAI failed msg_id=%s err=%s", message.id, type(e).__name__)
                 log.debug(traceback.format_exc())
                 # Safe user-facing message
-                reply = "(error calling model; see logs)"
+                reply = outage.user_message if outage else "(error calling model; see logs)"
 
         # Capture structured memory suggestions from the model (but do not auto-commit).
         # Format: [[MEMORY_SUGGEST]] {json...} [[/MEMORY_SUGGEST]]
@@ -1244,4 +1257,3 @@ class CallieBot(discord.Client):
             # Log sent messages to SQL
             #for sent in sent_messages:
                 
-

--- a/connectors/discord-connector/discord_helpers.py
+++ b/connectors/discord-connector/discord_helpers.py
@@ -3,13 +3,16 @@ import json
 import logging
 import random
 import re
+import socket
 import traceback
 from types import CoroutineType
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
+import aiohttp
 import discord
 
 from global_config import GlobalConfig
+from outage_helpers import classify_discord_exception, format_admin_outage
 from pk_helper import PKResolver
 _pk = PKResolver(ttl_seconds=3600)
 
@@ -707,6 +710,25 @@ async def send_with_retry(
                 log.debug(traceback.format_exc())
                 return None
 
+            await asyncio.sleep(float(retry_after))
+            continue
+
+        except (aiohttp.ClientConnectorError, socket.gaierror, TimeoutError, OSError) as e:
+            outage = classify_discord_exception(e)
+            backoff = retry_base_seconds * (2 ** (attempt - 1))
+            retry_after = min(retry_max_seconds, backoff) + (random.random() * retry_jitter_seconds)
+            detail = format_admin_outage(outage, context="send") if outage else f"Discord send network failure: {type(e).__name__}"
+            log.warning(
+                f"TX network trace={trace_id} part={part_idx}/{total_parts} "
+                f"attempt={attempt}/{max_retries} wait={retry_after:.2f}s {detail}"
+            )
+            if attempt >= max_retries:
+                log.error(
+                    f"TX giveup trace={trace_id} part={part_idx}/{total_parts} "
+                    f"network={type(e).__name__} after={attempt} attempts"
+                )
+                log.debug(traceback.format_exc())
+                return None
             await asyncio.sleep(float(retry_after))
             continue
 

--- a/connectors/discord-connector/outage_helpers.py
+++ b/connectors/discord-connector/outage_helpers.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import socket
+from typing import Optional
+
+import aiohttp
+import discord
+import httpx
+
+
+@dataclass(frozen=True)
+class ServiceOutage:
+    service: str
+    kind: str
+    admin_detail: str
+    user_message: str
+    retryable: bool = True
+
+
+def _status_from_httpx(exc: Exception) -> Optional[int]:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code
+    return None
+
+
+def classify_openai_exception(exc: Exception) -> Optional[ServiceOutage]:
+    status = _status_from_httpx(exc)
+    if status == 429:
+        return ServiceOutage(
+            service="OpenAI",
+            kind="rate_limit_or_quota",
+            admin_detail="OpenAI returned HTTP 429. This is rate limit, quota, or capacity pressure.",
+            user_message="Oops, looks like OpenAI is rate-limiting us right now. Let's try again later.",
+        )
+    if status is not None and 500 <= status <= 599:
+        return ServiceOutage(
+            service="OpenAI",
+            kind="upstream_5xx",
+            admin_detail=f"OpenAI returned HTTP {status}. Upstream service is unavailable or degraded.",
+            user_message="Oops, looks like OpenAI is not responding right now. Let's try again later.",
+        )
+    if isinstance(exc, (httpx.TimeoutException, httpx.ConnectError, httpx.NetworkError, socket.gaierror)):
+        return ServiceOutage(
+            service="OpenAI",
+            kind="network_or_dns",
+            admin_detail=f"OpenAI request failed before a usable response: {type(exc).__name__}.",
+            user_message="Oops, looks like OpenAI is not reachable right now. Let's try again later.",
+        )
+    return None
+
+
+def classify_discord_exception(exc: Exception) -> Optional[ServiceOutage]:
+    if isinstance(exc, (aiohttp.ClientConnectorDNSError, socket.gaierror)):
+        return ServiceOutage(
+            service="Discord",
+            kind="dns",
+            admin_detail=f"Discord DNS resolution failed: {type(exc).__name__}.",
+            user_message="Oops, looks like Discord is not reachable right now. Let's try again later.",
+        )
+    if isinstance(exc, (aiohttp.ClientConnectorError, TimeoutError, OSError)):
+        return ServiceOutage(
+            service="Discord",
+            kind="network",
+            admin_detail=f"Discord network connection failed: {type(exc).__name__}.",
+            user_message="Oops, looks like Discord is not responding right now. Let's try again later.",
+        )
+    if isinstance(exc, discord.HTTPException):
+        status = getattr(exc, "status", None)
+        if status == 429:
+            return ServiceOutage(
+                service="Discord",
+                kind="rate_limit",
+                admin_detail="Discord returned HTTP 429 while sending.",
+                user_message="Oops, looks like Discord is rate-limiting us right now. Let's try again later.",
+            )
+        if isinstance(status, int) and 500 <= status <= 599:
+            return ServiceOutage(
+                service="Discord",
+                kind="upstream_5xx",
+                admin_detail=f"Discord returned HTTP {status} while sending.",
+                user_message="Oops, looks like Discord is not responding right now. Let's try again later.",
+            )
+    return None
+
+
+def format_admin_outage(outage: ServiceOutage, *, context: str = "") -> str:
+    prefix = f"{outage.service} outage kind={outage.kind}"
+    if context:
+        prefix += f" context={context}"
+    return f"{prefix}: {outage.admin_detail}"


### PR DESCRIPTION
## Summary
- attach OpenAI Files API uploads back into Responses input as `input_file` parts
- classify Discord/OpenAI DNS, network, rate-limit, and upstream failures
- retry Discord send network failures and show safer user-facing outage text

## Validation
- `./.venv/bin/python -m py_compile connectors/discord-connector/callie_bot.py connectors/discord-connector/discord_helpers.py connectors/discord-connector/openai_helpers.py connectors/discord-connector/outage_helpers.py`
- outage classification smoke test with local connector venv