### PR TITLE
Fix Discord image context and reply prefixes

### DIFF
--- a/connectors/discord-connector/callie_bot.py
+++ b/connectors/discord-connector/callie_bot.py
@@ -27,6 +27,7 @@ from openai_helpers import build_trimmed_transcript, est_tokens, openai_respond,
 from outage_helpers import classify_discord_exception, classify_openai_exception, format_admin_outage
 from provider_backends import resolve_oauth_tokens, validate_provider_config
 from pk_helper import PKInfo, build_pk_context_block, format_pk_proxy_note
+from reply_cleanup import strip_obvious_reply_prefix
 from word_helpers import extract_docx_markdown, extract_text_bytes
 from access_control import AccessDecision, compute_access_decision #, ChannelReplyMode
 
@@ -305,7 +306,7 @@ class CallieBot(discord.Client):
         message: discord.Message,
         cfg: "GuildConfig",
         *,
-        invoked: bool,
+        should_process: bool,
     ) -> Tuple[List[Dict[str, Any]], List[str]]:
         """
         Process Discord message attachments into model-ready extra parts.
@@ -320,8 +321,7 @@ class CallieBot(discord.Client):
         extra_parts: List[Dict[str, Any]] = []
         user_notes: List[str] = []
 
-        # Policy: attachments only processed on explicit invocation
-        if not invoked or not message.attachments:
+        if not should_process or not message.attachments:
             return extra_parts, user_notes
 
         blocked: List[str] = []
@@ -456,6 +456,21 @@ class CallieBot(discord.Client):
             extra_parts.append(
                 {"type": "input_text", "text": "Connector note (shielded/blocked): " + " | ".join(user_notes)}
             )
+
+        image_parts = sum(1 for part in extra_parts if part.get("type") == "input_image")
+        file_parts = sum(1 for part in extra_parts if part.get("type") == "input_file")
+        text_parts = sum(1 for part in extra_parts if part.get("type") == "input_text")
+        log.info(
+            "Attachment processing msg_id=%s attachments=%s extra_parts=%s image_parts=%s file_parts=%s text_parts=%s blocked=%s shielded=%s",
+            message.id,
+            len(message.attachments),
+            len(extra_parts),
+            image_parts,
+            file_parts,
+            text_parts,
+            len(blocked),
+            len(shielded),
+        )
 
         return extra_parts, user_notes
 
@@ -1126,13 +1141,10 @@ class CallieBot(discord.Client):
                 )
                 validate_provider_config(provider_config)
 
-                # Vivian! Oh we have a place were we cared about invoked!
-                # TODO make this a policy we can set from global or guild config
-                # Attachment handling (explicit invocation only)
                 extra_parts, user_notes = await self._build_attachment_parts(
                     message,
                     cfg,
-                    invoked=bool(decision.is_invoked),
+                    should_process=bool(decision.can_speak),
                 )
                 system_prompt = await cfg.system_prompt()
                 max_output_tokens = await cfg.max_output_tokens()
@@ -1216,6 +1228,16 @@ class CallieBot(discord.Client):
             shield_msg = "(Attachment notes: " + " | ".join(user_notes) + ")"
             reply = shield_msg + "\n\n" + reply
 
+        cleanup_names = [
+            decision.effective_author.author_name,
+            getattr(message.author, "display_name", None),
+            getattr(message.author, "name", None),
+        ]
+        before_cleanup = reply
+        reply = strip_obvious_reply_prefix(reply, [str(name) for name in cleanup_names if name])
+        if reply != before_cleanup:
+            log.info("Reply cleanup: stripped leading addressee prefix msg_id=%s", message.id)
+
         limit = await cfg.discord_safe_limit()
         chunks = chunk_for_discord(reply, limit)
         log.info(f"TX plan: chunks={len(chunks)} sizes={[len(c) for c in chunks]} in_reply_to={message.id}")
@@ -1231,12 +1253,7 @@ class CallieBot(discord.Client):
             # If that fails (deleted message, etc), fall back to a standard send.
             if idx == 0:
                 try:
-                    pk_proxy_name = (
-                        getattr(message.author, "display_name", None)
-                        or getattr(message.author, "name", None)
-                        or None
-                    )
-                    factory = (lambda ch=chunk: send_reply(message, ch, pk_proxy_name=pk_proxy_name))
+                    factory = (lambda ch=chunk: send_reply(message, ch))
                     fallback_factory = (lambda ch=chunk: message.channel.send(ch, silent=True))
                 except Exception:
                     log.error("Failed to build PK-aware reply factory; falling back to standard reply.")

--- a/connectors/discord-connector/callie_bot.py
+++ b/connectors/discord-connector/callie_bot.py
@@ -486,6 +486,42 @@ class CallieBot(discord.Client):
             r.raise_for_status()
             return r.content
 
+    async def _maybe_send_attachment_invocation_reminder(
+        self,
+        message: discord.Message,
+        decision: AccessDecision,
+    ) -> None:
+        """
+        If attachments were withheld only because this was not an invocation,
+        tell the user how to get them inspected instead of silently dropping them.
+        """
+        if not getattr(message, "attachments", None):
+            return
+        if decision.is_invoked:
+            return
+        if not decision.record:
+            return
+        if decision.can_speak and not decision.speak_suppressed:
+            return
+
+        log.info(
+            "Attachment reminder: msg_id=%s attachments=%s mode=%s can_speak=%s speak_suppressed=%s reason=%s",
+            message.id,
+            len(message.attachments),
+            decision.mode.value,
+            decision.can_speak,
+            decision.speak_suppressed,
+            decision.reason,
+        )
+        reminder = (
+            "(Attachment note: I saw the upload, but I only inspect files/images when you mention me "
+            "or reply to me directly. Please resend it with a mention if you want me to look at it.)"
+        )
+        try:
+            await message.reply(reminder, mention_author=False)
+        except Exception as e:
+            log.warning("Attachment reminder send failed msg_id=%s err=%s", message.id, type(e).__name__)
+
     def _mark_pk_active(self, channel_id: int) -> None:
         self._pk_active_channels[channel_id] = time.time()
 
@@ -951,14 +987,17 @@ class CallieBot(discord.Client):
         raw_content = message.content or ""
 
         log.info(f"RX guild_id={message.guild.id if message.guild else None} "
-                 f"msg_id={message.id} author={author_name} author_id={message.author.id} chars={len(raw_content)}")
+                 f"msg_id={message.id} author={author_name} author_id={message.author.id} "
+                 f"chars={len(raw_content)} attachments={len(getattr(message, 'attachments', []) or [])}")
 
         # If we aren't allowed to speak, stop after recording/summary work.
         if not decision.can_speak:
+            await self._maybe_send_attachment_invocation_reminder(message, decision)
             log.info("Gate: speaking not allowed -> stop after recording")
             return
         # Ambient reply suppression
         if decision.speak_suppressed:
+            await self._maybe_send_attachment_invocation_reminder(message, decision)
             log.info("Gate: ambient/passive suppression -> stop after recording")
             return
         #if cfg.reply_policy == "Ambient":

--- a/connectors/discord-connector/discord_helpers.py
+++ b/connectors/discord-connector/discord_helpers.py
@@ -840,12 +840,10 @@ async def send_reply(
     *,
     pk_proxy_name: Optional[str] = None,
 ) -> discord.Message:
-    """Send a reply to a message, optionally prefixing with the PK proxy name."""
+    """Send a Discord reply without pinging or adding redundant speaker prefixes."""
     if pk_proxy_name:
-        reply_text = f"{pk_proxy_name}: {reply_text}"
-        return await message.reply(reply_text, mention_author=False)
-    else:
-        return await message.reply(reply_text, mention_author=False)
+        log.debug("send_reply ignored deprecated pk_proxy_name prefix for msg_id=%s", message.id)
+    return await message.reply(reply_text, mention_author=False)
 
 async def resolve_member_for_gate(message: discord.Message, member: Optional[discord.Member]):
     """

--- a/connectors/discord-connector/reply_cleanup.py
+++ b/connectors/discord-connector/reply_cleanup.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+
+_SPACE_RE = re.compile(r"\s+")
+
+
+def _norm_name(value: str) -> str:
+    return _SPACE_RE.sub(" ", str(value or "").strip())
+
+
+def reply_prefix_candidates(*names: str) -> List[str]:
+    """Return useful speaker names for conservative reply-prefix cleanup."""
+    candidates: List[str] = []
+    seen: set[str] = set()
+
+    for raw in names:
+        name = _norm_name(raw)
+        if not name:
+            continue
+
+        variants = {name}
+        quote_stripped = name.replace('"', "").replace("'", "")
+        variants.add(_norm_name(quote_stripped))
+
+        first = name.split(" ", 1)[0].strip()
+        if len(first) >= 3:
+            variants.add(first)
+
+        for variant in variants:
+            if len(variant) < 3:
+                continue
+            key = variant.casefold()
+            if key not in seen:
+                seen.add(key)
+                candidates.append(variant)
+
+    candidates.sort(key=len, reverse=True)
+    return candidates
+
+
+def strip_obvious_reply_prefix(reply: str, names: Iterable[str]) -> str:
+    """
+    Remove a leading "Name:" or "Name," when Discord's reply reference already
+    makes the recipient obvious.
+    """
+    text = str(reply or "")
+    leading = text[: len(text) - len(text.lstrip())]
+    body = text.lstrip()
+
+    for name in reply_prefix_candidates(*names):
+        pattern = re.compile(rf"^{re.escape(name)}\s*[:,]\s+", re.IGNORECASE)
+        match = pattern.match(body)
+        if not match:
+            continue
+        stripped = body[match.end() :].lstrip()
+        if stripped:
+            return leading + stripped
+
+    return text

--- a/connectors/discord-connector/smoke_reply_cleanup.py
+++ b/connectors/discord-connector/smoke_reply_cleanup.py
@@ -1,0 +1,38 @@
+from reply_cleanup import reply_prefix_candidates, strip_obvious_reply_prefix
+
+
+def _assert_eq(actual, expected):
+    if actual != expected:
+        raise AssertionError(f"expected {expected!r}, got {actual!r}")
+
+
+def main() -> int:
+    names = reply_prefix_candidates('Vivian "Brightwire" Kastali', "Vivian")
+    assert 'Vivian "Brightwire" Kastali' in names
+    assert "Vivian" in names
+
+    _assert_eq(
+        strip_obvious_reply_prefix(
+            'Vivian "Brightwire" Kastali: I can see the image now.',
+            names,
+        ),
+        "I can see the image now.",
+    )
+    _assert_eq(
+        strip_obvious_reply_prefix("Vivian, I can see the image now.", names),
+        "I can see the image now.",
+    )
+    _assert_eq(
+        strip_obvious_reply_prefix("Vivian should probably see this.", names),
+        "Vivian should probably see this.",
+    )
+    _assert_eq(
+        strip_obvious_reply_prefix("  Vivian: spaced reply", names),
+        "  spaced reply",
+    )
+    print("smoke_reply_cleanup ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- process Discord attachments whenever the connector is actually going to reply, so ambient/reply-allowed image messages produce base64 input_image context parts
- log RX attachment counts and attachment processing counts without logging payload data
- send a non-pinging Discord reminder when an allowed/recorded attachment message is skipped only because Callie was not invoked
- strip obvious leading addressee prefixes from model replies before sending to Discord
- stop prepending PK/display names in the Discord reply helper

## Validation
- .venv/bin/python -m py_compile connectors/discord-connector/callie_bot.py connectors/discord-connector/discord_helpers.py connectors/discord-connector/reply_cleanup.py connectors/discord-connector/smoke_reply_cleanup.py
- PYTHONPATH=connectors/discord-connector .venv/bin/python connectors/discord-connector/smoke_reply_cleanup.py
- PYTHONPATH=connectors/discord-connector .venv/bin/python connectors/discord-connector/smoke_cost_provider.py
- git diff --check

Closes #22
Closes #23