### PR TITLE
Make Discord attachment inspection policy configurable

### DIFF
--- a/connectors/discord-connector/.env.example
+++ b/connectors/discord-connector/.env.example
@@ -25,6 +25,12 @@ OPENAI_MODEL=gpt-5.2
 MAX_OUTPUT_TOKENS=1200
 CONTEXT_MESSAGES=180
 
+# Attachment inspection policy:
+# reply = inspect files/images whenever Callie is already going to reply.
+# invoked = require a mention/reply before inspecting files/images.
+# disabled = never inspect files/images.
+ATTACHMENT_INSPECTION_POLICY=reply
+
 # Cost telemetry
 # Prices are USD per 1M tokens. Use either defaults or per-model JSON.
 OPENAI_COST_LOG_ENABLED=1

--- a/connectors/discord-connector/.env.redacted
+++ b/connectors/discord-connector/.env.redacted
@@ -93,6 +93,10 @@ IGNORE_DEFAULT_MINUTES=15
 IGNORE_MAX_MINUTES=30
 
 # For file attachements
+# reply = inspect files/images whenever Callie is already going to reply.
+# invoked = require a mention/reply before inspecting files/images.
+# disabled = never inspect files/images.
+ATTACHMENT_INSPECTION_POLICY=reply
 MAX_ATTACHMENT_MB=50
 MAX_FILES_API_MB=512
 # Attachment extension policy (CSV lists; include dots or not, either works)

--- a/connectors/discord-connector/callie_bot.py
+++ b/connectors/discord-connector/callie_bot.py
@@ -490,6 +490,10 @@ class CallieBot(discord.Client):
         self,
         message: discord.Message,
         decision: AccessDecision,
+        *,
+        force: bool = False,
+        source: str = "gate",
+        reminder: Optional[str] = None,
     ) -> None:
         """
         If attachments were withheld only because this was not an invocation,
@@ -501,22 +505,24 @@ class CallieBot(discord.Client):
             return
         if not decision.record:
             return
-        if decision.can_speak and not decision.speak_suppressed:
+        if not force and decision.can_speak and not decision.speak_suppressed:
             return
 
         log.info(
-            "Attachment reminder: msg_id=%s attachments=%s mode=%s can_speak=%s speak_suppressed=%s reason=%s",
+            "Attachment reminder: msg_id=%s attachments=%s source=%s mode=%s can_speak=%s speak_suppressed=%s reason=%s",
             message.id,
             len(message.attachments),
+            source,
             decision.mode.value,
             decision.can_speak,
             decision.speak_suppressed,
             decision.reason,
         )
-        reminder = (
-            "(Attachment note: I saw the upload, but I only inspect files/images when you mention me "
-            "or reply to me directly. Please resend it with a mention if you want me to look at it.)"
-        )
+        if reminder is None:
+            reminder = (
+                "(Attachment note: I saw the upload, but I only inspect files/images when you mention me "
+                "or reply to me directly. Please resend it with a mention if you want me to look at it.)"
+            )
         try:
             await message.reply(reminder, mention_author=False)
         except Exception as e:
@@ -1000,6 +1006,36 @@ class CallieBot(discord.Client):
             await self._maybe_send_attachment_invocation_reminder(message, decision)
             log.info("Gate: ambient/passive suppression -> stop after recording")
             return
+
+        attachment_policy = await cfg.attachment_inspection_policy()
+        if getattr(message, "attachments", None):
+            log.info(
+                "Attachment policy msg_id=%s policy=%s invoked=%s can_speak=%s attachments=%s",
+                message.id,
+                attachment_policy,
+                decision.is_invoked,
+                decision.can_speak,
+                len(message.attachments),
+            )
+        if attachment_policy == "disabled" and getattr(message, "attachments", None):
+            log.info("Attachment policy disabled -> stop before model msg_id=%s", message.id)
+            await self._maybe_send_attachment_invocation_reminder(
+                message,
+                decision,
+                force=True,
+                source="attachment_policy_disabled",
+                reminder="(Attachment note: file/image inspection is currently disabled for this connector.)",
+            )
+            return
+        if attachment_policy == "invoked" and getattr(message, "attachments", None) and not decision.is_invoked:
+            await self._maybe_send_attachment_invocation_reminder(
+                message,
+                decision,
+                force=True,
+                source="attachment_policy_requires_invocation",
+            )
+            log.info("Attachment policy requires invocation -> stop before model msg_id=%s", message.id)
+            return
         #if cfg.reply_policy == "Ambient":
         #    if should_suppress_ambient_reply(
         #      message, bot_user=self.user,
@@ -1183,7 +1219,10 @@ class CallieBot(discord.Client):
                 extra_parts, user_notes = await self._build_attachment_parts(
                     message,
                     cfg,
-                    should_process=bool(decision.can_speak),
+                    should_process=bool(
+                        decision.can_speak
+                        and (attachment_policy == "reply" or decision.is_invoked)
+                    ),
                 )
                 system_prompt = await cfg.system_prompt()
                 max_output_tokens = await cfg.max_output_tokens()

--- a/connectors/discord-connector/guild_config.py
+++ b/connectors/discord-connector/guild_config.py
@@ -355,6 +355,35 @@ class GuildConfig:
         #return await self.get_int("DISCORD_SAFE_LIMIT", 1900)
 
     # Attachments
+    async def attachment_inspection_policy(self) -> str:
+        """
+        reply: inspect attachments whenever Callie is going to reply.
+        invoked: inspect attachments only when the user explicitly mentions/replies to Callie.
+        disabled: never inspect attachments.
+        """
+        raw = ((await self.get_str("ATTACHMENT_INSPECTION_POLICY", "reply")) or "reply").strip().lower()
+        aliases = {
+            "allow": "reply",
+            "allowed": "reply",
+            "replying": "reply",
+            "when_replying": "reply",
+            "mention": "invoked",
+            "mentions": "invoked",
+            "require_mention": "invoked",
+            "require_mentions": "invoked",
+            "require_invocation": "invoked",
+            "invocation": "invoked",
+            "off": "disabled",
+            "none": "disabled",
+            "never": "disabled",
+            "deny": "disabled",
+        }
+        policy = aliases.get(raw, raw)
+        if policy not in {"reply", "invoked", "disabled"}:
+            log.warning("Invalid ATTACHMENT_INSPECTION_POLICY=%r; using reply", raw)
+            return "reply"
+        return policy
+
     async def max_attachment_mb(self) -> float:
         """This is the softer limit for PDFs and images we try to inline. Default 10 MB."""
         return await self.get_float("MAX_ATTACHMENT_MB", 10.0)


### PR DESCRIPTION
## Summary
- add ATTACHMENT_INSPECTION_POLICY with default reply mode
- support invoked mode for require-mention/reply attachment inspection
- support disabled mode for hard-off attachment inspection
- make blocked attachment reminders policy-aware
- document the env setting in sample env files

## Validation
- .venv/bin/python -m py_compile connectors/discord-connector/callie_bot.py connectors/discord-connector/guild_config.py connectors/discord-connector/discord_helpers.py connectors/discord-connector/reply_cleanup.py connectors/discord-connector/smoke_reply_cleanup.py
- PYTHONPATH=connectors/discord-connector .venv/bin/python connectors/discord-connector/smoke_reply_cleanup.py
- PYTHONPATH=connectors/discord-connector .venv/bin/python connectors/discord-connector/smoke_cost_provider.py
- git diff --check