### PR TITLE
Add configurable Discord reply diagnostics UI

### DIFF
--- a/connectors/discord-connector/.env.example
+++ b/connectors/discord-connector/.env.example
@@ -25,6 +25,13 @@ OPENAI_MODEL=gpt-5.2
 MAX_OUTPUT_TOKENS=1200
 CONTEXT_MESSAGES=180
 
+# Reply diagnostics:
+# off = no user-visible diagnostics.
+# spoiler = append a tiny click-to-reveal spoiler footer.
+# button = attach a Details button with ephemeral diagnostics.
+# both = spoiler footer plus Details button.
+REPLY_DIAGNOSTICS_MODE=off
+
 # Cost telemetry
 # Prices are USD per 1M tokens. Use either defaults or per-model JSON.
 OPENAI_COST_LOG_ENABLED=1

--- a/connectors/discord-connector/.env.redacted
+++ b/connectors/discord-connector/.env.redacted
@@ -85,6 +85,12 @@ MAX_OUTPUT_TOKENS_LONG=2800
 CONTEXT_MESSAGES=180
 CONTEXT_TOKEN_LIMIT=12000
 CONTEXT_SUMMARY_TARGET_TOKENS=180
+# Reply diagnostics:
+# off = no user-visible diagnostics.
+# spoiler = append a tiny click-to-reveal spoiler footer.
+# button = attach a Details button with ephemeral diagnostics.
+# both = spoiler footer plus Details button.
+REPLY_DIAGNOSTICS_MODE=off
 # A safetty holder for sending messages to OpenAI
 REQUIRE_SERVER_CONTEXT=true
 

--- a/connectors/discord-connector/callie_bot.py
+++ b/connectors/discord-connector/callie_bot.py
@@ -59,6 +59,73 @@ RECENT_AUTHORS = deque(maxlen=10)
 BOT_INSTANCE: Optional[discord.Client] = None
 MAIN_LOOP: asyncio.AbstractEventLoop | None = None
 
+
+def _fmt_diag_int(value: Any) -> str:
+    try:
+        if value is None:
+            return "?"
+        return f"{int(value):,}"
+    except Exception:
+        return "?"
+
+
+def _fmt_diag_money(value: Any) -> str:
+    try:
+        if value is None:
+            return "?"
+        return f"${float(value):.6f}"
+    except Exception:
+        return "?"
+
+
+def _fmt_diag_pct(value: Any) -> str:
+    try:
+        if value is None:
+            return "?"
+        return f"{float(value):.1f}%"
+    except Exception:
+        return "?"
+
+
+def _reply_diagnostics_brief(diagnostics: Dict[str, Any]) -> str:
+    model = diagnostics.get("model") or "?"
+    backend = diagnostics.get("backend") or diagnostics.get("provider") or "?"
+    auth_mode = diagnostics.get("auth_mode") or "?"
+    total = _fmt_diag_int(diagnostics.get("total_tokens"))
+    cost = _fmt_diag_money(diagnostics.get("estimated_cost_usd"))
+    return f"model={model} · backend={backend}/{auth_mode} · tokens={total} · est={cost}"
+
+
+def _reply_diagnostics_details(diagnostics: Dict[str, Any]) -> str:
+    lines = [
+        "Reply diagnostics",
+        f"model: {diagnostics.get('model') or '?'}",
+        f"backend: {diagnostics.get('backend') or diagnostics.get('provider') or '?'}",
+        f"auth_mode: {diagnostics.get('auth_mode') or '?'}",
+        f"response_id: {diagnostics.get('response_id') or '?'}",
+        f"latency_ms: {_fmt_diag_int(diagnostics.get('dt_ms'))}",
+        f"input_tokens: {_fmt_diag_int(diagnostics.get('input_tokens'))}",
+        f"output_tokens: {_fmt_diag_int(diagnostics.get('output_tokens'))}",
+        f"total_tokens: {_fmt_diag_int(diagnostics.get('total_tokens'))}",
+        f"estimated_cost: {_fmt_diag_money(diagnostics.get('estimated_cost_usd'))}",
+        f"budget_used_pct: {_fmt_diag_pct(diagnostics.get('budget_used_pct'))}",
+        f"pricing_source: {diagnostics.get('pricing_source') or '?'}",
+        f"attachment_parts: image={diagnostics.get('image_parts', 0)} file={diagnostics.get('file_parts', 0)} text={diagnostics.get('text_parts', 0)}",
+    ]
+    if diagnostics.get("estimated_input_tokens") is not None:
+        lines.append(f"estimated_prompt_tokens: {_fmt_diag_int(diagnostics.get('estimated_input_tokens'))}")
+    return "\n".join(lines)[:1900]
+
+
+class ReplyDiagnosticsView(discord.ui.View):
+    def __init__(self, diagnostics: Dict[str, Any]):
+        super().__init__(timeout=24 * 60 * 60)
+        self._details = _reply_diagnostics_details(diagnostics)
+
+    @discord.ui.button(label="Details", style=discord.ButtonStyle.secondary)
+    async def details_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message(self._details, ephemeral=True)
+
 # It is not great that this gets called directly from inside the message processing function.
 # We may want to refactor this later to use an event or similar.
 def _record_author(message: discord.Message) -> None:
@@ -1164,6 +1231,7 @@ class CallieBot(discord.Client):
         # Call OpenAI to get a response
         extra_parts: List[Dict[str, Any]] = []
         user_notes: List[str] = []
+        reply_diagnostics: Dict[str, Any] = {}
         async with message.channel.typing():
             try:
                 provider_config = await cfg.connector_provider_config()
@@ -1196,7 +1264,7 @@ class CallieBot(discord.Client):
                 if not isinstance(max_output_tokens, int) or max_output_tokens <= 0:
                     raise RuntimeError(f"Invalid max_output_tokens={max_output_tokens!r}")
 
-                reply, response_id = await openai_respond(
+                reply, response_id, reply_diagnostics = await openai_respond(
                     system_prompt=system_prompt,
                     memory_blob=memory_blob,
                     transcript=transcript,
@@ -1208,6 +1276,18 @@ class CallieBot(discord.Client):
                     extra_content_parts=extra_parts,
                     cost_telemetry=await cfg.cost_telemetry_config(),
                     provider_config=provider_config,
+                )
+                image_parts = sum(1 for part in extra_parts if part.get("type") == "input_image")
+                file_parts = sum(1 for part in extra_parts if part.get("type") == "input_file")
+                text_parts = sum(1 for part in extra_parts if part.get("type") == "input_text")
+                reply_diagnostics.update(
+                    {
+                        "backend": provider_config.backend,
+                        "auth_mode": provider_config.auth_mode,
+                        "image_parts": image_parts,
+                        "file_parts": file_parts,
+                        "text_parts": text_parts,
+                    }
                 )
 
                 log.info("OpenAI response_id=%s chars=%s for msg_id=%s", response_id, len(reply), message.id)
@@ -1277,6 +1357,13 @@ class CallieBot(discord.Client):
         if reply != before_cleanup:
             log.info("Reply cleanup: stripped leading addressee prefix msg_id=%s", message.id)
 
+        diagnostics_mode = await cfg.reply_diagnostics_mode()
+        diagnostics_view: Optional[ReplyDiagnosticsView] = None
+        if diagnostics_mode in {"spoiler", "both"} and reply_diagnostics:
+            reply += f"\n\n||{_reply_diagnostics_brief(reply_diagnostics)}||"
+        if diagnostics_mode in {"button", "both"} and reply_diagnostics:
+            diagnostics_view = ReplyDiagnosticsView(reply_diagnostics)
+
         limit = await cfg.discord_safe_limit()
         chunks = chunk_for_discord(reply, limit)
         log.info(f"TX plan: chunks={len(chunks)} sizes={[len(c) for c in chunks]} in_reply_to={message.id}")
@@ -1292,12 +1379,12 @@ class CallieBot(discord.Client):
             # If that fails (deleted message, etc), fall back to a standard send.
             if idx == 0:
                 try:
-                    factory = (lambda ch=chunk: send_reply(message, ch))
-                    fallback_factory = (lambda ch=chunk: message.channel.send(ch, silent=True))
+                    factory = (lambda ch=chunk: send_reply(message, ch, view=diagnostics_view))
+                    fallback_factory = (lambda ch=chunk: message.channel.send(ch, silent=True, view=diagnostics_view))
                 except Exception:
                     log.error("Failed to build PK-aware reply factory; falling back to standard reply.")
-                    factory = (lambda ch=chunk: message.reply(ch, mention_author=False))
-                    fallback_factory = (lambda ch=chunk: message.channel.send(ch, silent=True))
+                    factory = (lambda ch=chunk: message.reply(ch, mention_author=False, view=diagnostics_view))
+                    fallback_factory = (lambda ch=chunk: message.channel.send(ch, silent=True, view=diagnostics_view))
             else:
                 factory = (lambda ch=chunk: message.channel.send(ch, reference=message, silent=True))
                 fallback_factory = (lambda ch=chunk: message.channel.send("(Context note: I couldn't reply directly because the referenced message was deleted or unavailable.)\n\n" + ch, silent=True))

--- a/connectors/discord-connector/codex_transport.py
+++ b/connectors/discord-connector/codex_transport.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import httpx
 
 from callie_logging import setup_logging
-from cost_tracking import CostTelemetryConfig, calculate_usage_cost, format_cost_log
+from cost_tracking import CostTelemetryConfig, calculate_usage_cost, format_cost_log, usage_cost_to_dict
 from provider_backends import ConnectorProviderConfig, resolve_oauth_tokens
 
 log, _log_settings = setup_logging("codex_transport")
@@ -133,7 +133,7 @@ async def codex_respond(
     provider_config: ConnectorProviderConfig,
     model: str,
     cost_telemetry: Optional[CostTelemetryConfig] = None,
-) -> Tuple[str, str]:
+) -> Tuple[str, str, Dict[str, Any]]:
     tokens = resolve_oauth_tokens(provider_config)
     if not tokens.has_access:
         raise RuntimeError("OPENAI_OAUTH_TOKEN or OPENAI_OAUTH_TOKEN_PATH is missing.")
@@ -178,9 +178,12 @@ async def codex_respond(
     text, final_response = _extract_text_from_events(events)
     response_id = str(final_response.get("id") or "")
     text = text or "(no output)"
+    if cost_telemetry is None:
+        cost_telemetry = CostTelemetryConfig(enabled=False)
+    cost = calculate_usage_cost(final_response, model, cost_telemetry) if final_response else None
     cost_log = ""
-    if cost_telemetry is not None and cost_telemetry.enabled and final_response:
-        cost_log = " " + format_cost_log(calculate_usage_cost(final_response, model, cost_telemetry))
+    if cost_telemetry.enabled and cost is not None:
+        cost_log = " " + format_cost_log(cost)
     log.info(
         "Codex ok response_id=%s dt_ms=%s input_chars=%s out_chars=%s model=%s max_out_tokens=%s%s",
         response_id,
@@ -191,4 +194,15 @@ async def codex_respond(
         max_output_tokens,
         cost_log,
     )
-    return text, response_id
+    diagnostics: Dict[str, Any] = {
+        "provider": "codex",
+        "response_id": response_id,
+        "model": model,
+        "dt_ms": int((time.time() - t0) * 1000),
+        "input_chars": len(full_input),
+        "max_output_tokens": max_output_tokens,
+        "output_chars": len(text),
+    }
+    if cost is not None:
+        diagnostics.update(usage_cost_to_dict(cost))
+    return text, response_id, diagnostics

--- a/connectors/discord-connector/cost_tracking.py
+++ b/connectors/discord-connector/cost_tracking.py
@@ -176,3 +176,20 @@ def format_cost_log(cost: UsageCost) -> str:
         f"total_tokens={cost.total_tokens if cost.total_tokens is not None else 'unknown'} "
         f"{cost_part} pricing_source={cost.pricing_source} {budget_part}"
     )
+
+
+def usage_cost_to_dict(cost: UsageCost) -> Dict[str, Any]:
+    budget_used_pct: Optional[float] = None
+    if cost.monthly_budget_usd > 0:
+        budget_used_pct = (cost.effective_month_to_date_usd / cost.monthly_budget_usd) * 100.0
+    return {
+        "input_tokens": cost.input_tokens,
+        "output_tokens": cost.output_tokens,
+        "total_tokens": cost.total_tokens,
+        "estimated_cost_usd": cost.estimated_cost_usd,
+        "pricing_source": cost.pricing_source,
+        "connector_month_to_date_usd": cost.connector_month_to_date_usd,
+        "effective_month_to_date_usd": cost.effective_month_to_date_usd,
+        "monthly_budget_usd": cost.monthly_budget_usd,
+        "budget_used_pct": budget_used_pct,
+    }

--- a/connectors/discord-connector/discord_helpers.py
+++ b/connectors/discord-connector/discord_helpers.py
@@ -839,11 +839,12 @@ async def send_reply(
     reply_text: str,
     *,
     pk_proxy_name: Optional[str] = None,
+    view: Optional[discord.ui.View] = None,
 ) -> discord.Message:
     """Send a Discord reply without pinging or adding redundant speaker prefixes."""
     if pk_proxy_name:
         log.debug("send_reply ignored deprecated pk_proxy_name prefix for msg_id=%s", message.id)
-    return await message.reply(reply_text, mention_author=False)
+    return await message.reply(reply_text, mention_author=False, view=view)
 
 async def resolve_member_for_gate(message: discord.Message, member: Optional[discord.Member]):
     """

--- a/connectors/discord-connector/guild_config.py
+++ b/connectors/discord-connector/guild_config.py
@@ -339,6 +339,36 @@ class GuildConfig:
     async def suppress_ambient_replies(self) -> bool:
         return await self.get_bool("SUPPRESS_AMBIENT_REPLIES", False)
 
+    async def reply_diagnostics_mode(self) -> str:
+        """
+        off: do not add reply diagnostics.
+        spoiler: append a tiny click-to-reveal spoiler footer.
+        button: attach a Details button that opens an ephemeral diagnostic message.
+        both: add both the spoiler footer and the Details button.
+        """
+        raw = ((await self.get_str("REPLY_DIAGNOSTICS_MODE", "off")) or "off").strip().lower()
+        aliases = {
+            "0": "off",
+            "false": "off",
+            "no": "off",
+            "none": "off",
+            "disabled": "off",
+            "1": "spoiler",
+            "true": "spoiler",
+            "yes": "spoiler",
+            "footer": "spoiler",
+            "hidden": "spoiler",
+            "details": "button",
+            "buttons": "button",
+            "all": "both",
+            "full": "both",
+        }
+        mode = aliases.get(raw, raw)
+        if mode not in {"off", "spoiler", "button", "both"}:
+            log.warning("Invalid REPLY_DIAGNOSTICS_MODE=%r; using off", raw)
+            return "off"
+        return mode
+
     # Discord chunking
 
     async def discord_msg_limit(self) -> int:

--- a/connectors/discord-connector/openai_helpers.py
+++ b/connectors/discord-connector/openai_helpers.py
@@ -9,7 +9,7 @@ import httpx
 
 from callie_logging import log, setup_logging
 from codex_transport import codex_respond
-from cost_tracking import CostTelemetryConfig, calculate_usage_cost, format_cost_log
+from cost_tracking import CostTelemetryConfig, calculate_usage_cost, format_cost_log, usage_cost_to_dict
 from guild_config import GuildConfig
 from helpers import _iso_utc
 from provider_backends import ConnectorProviderConfig, OPENAI_API_BACKEND
@@ -178,7 +178,7 @@ async def openai_respond(
     extra_content_parts: Optional[List[Dict]] = None,
     cost_telemetry: Optional[CostTelemetryConfig] = None,
     provider_config: Optional[ConnectorProviderConfig] = None,
-) -> Tuple[str, str]:
+) -> Tuple[str, str, Dict[str, Any]]:
     api_key_to_use = (api_key if api_key is not None else "").strip()
     model_to_use = (model if model is not None else "gpt-4o-mini").strip() 
     ## we used to use else (os.getenv("OPENAI_API_KEY") / else (os.getenv("OPENAI_MODEL") but we are moving away from doing that
@@ -222,7 +222,7 @@ async def openai_respond(
 
     if not api_key or api_key_to_use == "":
         log.error("OpenAI API key is missing!")
-        return "Sorry, nobody put in an Open AI key yet. Tell the server admin to fix the configuration.", "0"
+        return "Sorry, nobody put in an Open AI key yet. Tell the server admin to fix the configuration.", "0", {}
     headers = {
         "Authorization": f"Bearer {api_key_to_use}",
         "Content-Type": "application/json",
@@ -249,9 +249,8 @@ async def openai_respond(
     response_id = str(data.get("id", ""))
     if cost_telemetry is None:
         cost_telemetry = CostTelemetryConfig(enabled=False)
-    cost_log = ""
-    if cost_telemetry.enabled:
-        cost_log = " " + format_cost_log(calculate_usage_cost(data, model_to_use, cost_telemetry))
+    cost = calculate_usage_cost(data, model_to_use, cost_telemetry)
+    cost_log = " " + format_cost_log(cost) if cost_telemetry.enabled else ""
 
     out_text: List[str] = []
     for item in data.get("output", []):
@@ -266,7 +265,17 @@ async def openai_respond(
         f"in_est_tokens≈{est_input_tokens} out_chars={len(text)} model={model_to_use} max_out_tokens={max_output_tokens}"
         f"{cost_log}"
     )
-    return text, response_id
+    diagnostics: Dict[str, Any] = {
+        "provider": "openai",
+        "response_id": response_id,
+        "model": model_to_use,
+        "dt_ms": dt_ms,
+        "estimated_input_tokens": est_input_tokens,
+        "max_output_tokens": max_output_tokens,
+        "output_chars": len(text),
+        **usage_cost_to_dict(cost),
+    }
+    return text, response_id, diagnostics
 
 async def openai_upload_file(
         data: bytes, 

--- a/connectors/discord-connector/smoke_cost_provider.py
+++ b/connectors/discord-connector/smoke_cost_provider.py
@@ -11,7 +11,7 @@ from codex_transport import (
     _unsupported_parameter_from_message,
     extract_codex_account_id,
 )
-from cost_tracking import CostTelemetryConfig, calculate_usage_cost, format_cost_log
+from cost_tracking import CostTelemetryConfig, calculate_usage_cost, format_cost_log, usage_cost_to_dict
 from provider_backends import (
     ConnectorProviderConfig,
     normalize_provider_backend,
@@ -42,6 +42,9 @@ def main() -> None:
     rendered = format_cost_log(cost)
     assert "cost_estimate_usd=" in rendered
     assert "budget_used_pct=" in rendered
+    diag = usage_cost_to_dict(cost)
+    assert diag["input_tokens"] == 1000
+    assert diag["budget_used_pct"] is not None
 
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as f:
         f.write('{"gpt-test":{"input_cost_per_million":2.0,"output_cost_per_million":8.0}}')


### PR DESCRIPTION
## Summary
- add REPLY_DIAGNOSTICS_MODE with off/spoiler/button/both modes
- return structured reply diagnostics from OpenAI API and authenticated-session/Codex transports
- append a tiny spoiler footer when configured
- attach a Discord Details button that opens ephemeral model/token/cost details when configured
- include model/backend/auth mode, response id, latency, token usage, estimated cost, budget percentage, pricing source, and attachment part counts

## Validation
- .venv/bin/python -m py_compile connectors/discord-connector/callie_bot.py connectors/discord-connector/openai_helpers.py connectors/discord-connector/codex_transport.py connectors/discord-connector/cost_tracking.py connectors/discord-connector/guild_config.py connectors/discord-connector/discord_helpers.py connectors/discord-connector/smoke_cost_provider.py
- PYTHONPATH=connectors/discord-connector .venv/bin/python connectors/discord-connector/smoke_reply_cleanup.py
- PYTHONPATH=connectors/discord-connector .venv/bin/python connectors/discord-connector/smoke_cost_provider.py
- git diff --check